### PR TITLE
Quote file paths to handle spaces in file names

### DIFF
--- a/gooey/gui/widgets/widget_pack.py
+++ b/gooey/gui/widgets/widget_pack.py
@@ -59,9 +59,9 @@ class BaseChooser(WidgetPack):
 
   def getValue(self):
     if self.option_string:
-      return '{0} {1}'.format(self.option_string, self.text_box.GetValue())
+      return '{0} "{1}"'.format(self.option_string, self.text_box.GetValue())
     else:
-      return self.text_box.GetValue()
+      return '"{}"'.format(self.text_box.GetValue())
 
   def onButton(self, evt):
     raise NotImplementedError


### PR DESCRIPTION
Currently, a space in a filename results in the path being split into two arguments when passed to the python script and it will disrupt any other positional arguments

I'm not too familiar with the codebase, so maybe there's something else I need to add before this is ready to merge. Let me know if there's anything I can do!