### PR TITLE
Various fixes and AutoGooey

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,8 +187,13 @@ Note: notice that you still need to decorate your function with @Gooey.
 
 | Widget         |           Example            | 
 |----------------|------------------------------| 
-|  Directory/FileChooser   | <p align="center"><img src="https://raw.githubusercontent.com/chriskiehl/Gooey/master/resources/filechooser.gif" width="400"></p> | 
+|  FileChooser<br />FileSaver<br />DirChooser<br />MultiFileChooser   | <p align="center"><img src="https://raw.githubusercontent.com/chriskiehl/Gooey/master/resources/filechooser.gif" width="400"></p> | 
 |  DateChooser   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;| <p align="center"><img src="https://raw.githubusercontent.com/chriskiehl/Gooey/master/resources/datechooser.gif" width="400"></p> |  
+|  TextField   |  | 
+|  Dropdown   |  | 
+|  Counter   |  | 
+|  RadioGroup   |  | 
+|  CheckBox   |  | 
  
   
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ If the above defaults aren't cutting it, you can control the exact widget type b
 
     from argparse import ArgumentParser
     ....
-    
+
     def main(): 
         parser = ArgumentParser(description="My Cool Gooey App!")
         parser.add_argument('filename', help="name of the file to process") 
@@ -168,12 +168,14 @@ Given then above, Gooey would select a normal `TextField` as the widget type lik
     <img src="https://raw.githubusercontent.com/chriskiehl/Gooey/master/resources/textfield_demo.PNG">
 </p>
 
-However, by dropping in `GooeyParser` and supplying a `widget` name, you display a much more user friendly `FileChooser` 
+However, by dropping in `GooeyParser` and supplying a `widget` name, you display a much more user friendly `FileChooser`.
 
+Note: notice that you still need to decorate your function with @Gooey.
 
-    from gooeyimport GooeyParser
+    from gooey import Gooey, GooeyParser
     ....
-    
+
+    @Gooey
     def main(): 
         parser = GooeyParser(description="My Cool Gooey App!")
         parser.add_argument('filename', help="name of the file to process", widget='FileChooser') 
@@ -201,11 +203,11 @@ However, by dropping in `GooeyParser` and supplying a `widget` name, you display
 Configuration 
 ------------   
 
-Gooey comes in three main flavors.  
+Gooey can show three kinds of GUI.
 
-- Full/Advanced 
+- Full/Advanced
 - Basic
-- No config  
+- No config
 
 Each has the following options: 
 
@@ -266,6 +268,59 @@ No Config pretty much does what you'd expect: it doesn't show a configuration sc
 </p>
 
 ---------------------------------------  
+
+
+###AutoGooey
+
+When using the @Gooey decorator, your script will always display a GUI. If you want to offer both interfaces (command-line and GUI), you can use this code snippet:
+
+    # Try to import Gooey for GUI display, but manage exception so that we replace the Gooey decorator by a dummy function that will just return the main function as-is, thus keeping the compatibility with command-line usage
+    try:
+        import lib.gooey as gooey
+    except:
+        # Define a dummy replacement function for Gooey to stay compatible with command-line usage
+        class gooey(object):
+            def Gooey(func):
+                return func
+        # If --gui was specified, then there's a problem
+        if len(sys.argv) > 1 and sys.argv[1] == '--gui': raise ImportError('--gui specified but lib/gooey could not be found, cannot load the GUI (however you can still use in commandline).')
+
+    def check_gui_arg():
+        '''Check that the --gui argument was passed, and if true, we remove the --gui option and replace by --gui_launched so that Gooey does not loop infinitely'''
+        if len(sys.argv) > 1 and sys.argv[1] == '--gui':
+            #del sys.argv[1]
+            sys.argv[1] = '--gui_launched' # CRITICAL: need to remove/replace the --gui argument, else it will stay in memory and when Gooey will call the script again, it will be stuck in an infinite loop calling back and forth between this script and Gooey. Thus, we need to remove this argument, but we also need to be aware that Gooey was called so that we can call gooey.GooeyParser() instead of argparse.ArgumentParser() (for better fields management like checkboxes for boolean arguments). To solve both issues, we replace the argument --gui by another internal argument --gui_launched.
+            return True
+        else:
+            return False
+
+    def AutoGooey(fn):
+        '''Automatically show a Gooey GUI if --gui is passed as the first argument, else it will just run the function as normal'''
+        if check_gui_arg():
+            return gooey.Gooey(fn)
+        else:
+            return fn
+
+    @AutoGooey
+    def main(argv=None):
+        # ... your program here ...
+
+And then when parsing command-line arguments, you can detect if your script is running inside Gooey or from command-line:
+
+    @AutoGooey
+    def main(argv=None):
+        #-- Constructing the parser
+        if len(sys.argv) > 1 and sys.argv[1] == '--gui_launched':
+            main_parser = gooey.GooeyParser()
+        else:
+            main_parser = argparse.ArgumentParser()
+        #-- Constructing arguments
+        main_parser.add_argument('-i', '--input', metavar='/path/to/root/folder', type=str, required=True,
+                            help='Path to the root folder from where the scanning will occur.')
+
+
+---------------------------------------  
+
 
 Final Screen
 ------------  

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Table of Contents
     - [Full/Advanced](#advanced)
     - [Basic](#basic)
     - [No Config](#no-config)
+    - [AutoGooey](#autogooey)
 - [Final Screen](#final-screen)
 - [Change Log](#change-log)
 - [TODO](#todo)

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Different styling and functionality can be configured by passing arguments into 
     # options
     @Gooey(advanced=Boolean,          # toggle whether to show advanced config or not 
            language=language_string,  # Translations configurable via json
-           config=Boolean,            # skip config screens all together
+           show_config=Boolean,            # skip config screens all together
            program_name='name',       # Defaults to script name 
            program_description        # Defaults to ArgParse Description
       )

--- a/README.md
+++ b/README.md
@@ -319,6 +319,8 @@ And then when parsing command-line arguments, you can detect if your script is r
         main_parser.add_argument('-i', '--input', metavar='/path/to/root/folder', type=str, required=True,
                             help='Path to the root folder from where the scanning will occur.')
 
+You can then just call your script using --gui as the first argument (eg, `python yourscript.py --gui`) to show the Gooey GUI, or just omit this argument and use your script from command-line as usual.
+
 
 ---------------------------------------  
 

--- a/gooey/gui/components.py
+++ b/gooey/gui/components.py
@@ -332,7 +332,7 @@ class Optional(AbstractComponent):
     '''
     self.AssertInitialization('Optional')
     value = self._widget.GetValue()
-    if not value:
+    if not value or len(value) <= 0:
       return None
     return ' '.join(
       [self._action.option_strings[0],  # get the verbose copy if available
@@ -387,8 +387,10 @@ class Flag(AbstractComponent):
     returns
       Options name for argument (-v)
     '''
-    if self._widget.GetValue():
-      return self._action.option_strings[0]
+    if not self._widget.GetValue() or len(self._widget.GetValue()) <= 0:
+        return None
+    else:
+        return self._action.option_strings[0]
 
   def Update(self, size):
     '''

--- a/gooey/gui/widgets/components2.py
+++ b/gooey/gui/widgets/components2.py
@@ -68,7 +68,7 @@ class BaseGuiComponent(object):
     return text
 
   def formatExtendedHelpMsg(self, data):
-    base_text = data.get('help_msg', '')
+    base_text = data.get('help', '')
     nargs = data['nargs']
     if isinstance(nargs, int):
       return '{base}\n(Note: exactly {nargs} arguments are required)'.format(base=base_text, nargs=nargs)

--- a/gooey/gui/widgets/widget_pack.py
+++ b/gooey/gui/widgets/widget_pack.py
@@ -58,10 +58,11 @@ class BaseChooser(WidgetPack):
     return widget_sizer
 
   def getValue(self):
-    if self.option_string:
+    if self.option_string and self.text_box.GetValue() and len(self.text_box.GetValue()) > 0:
       return '{0} "{1}"'.format(self.option_string, self.text_box.GetValue())
     else:
-      return '"{}"'.format(self.text_box.GetValue())
+      #return '"{}"'.format(self.text_box.GetValue())
+      return None
 
   def onButton(self, evt):
     raise NotImplementedError

--- a/gooey/gui/windows/advanced_config.py
+++ b/gooey/gui/windows/advanced_config.py
@@ -114,10 +114,16 @@ class AdvancedConfigPanel(ScrolledPanel, OptionReader):
     return ' '.join(values)
 
   def GetRequiredArgs(self):
-    return [arg.GetValue() for arg in self.components.required_args]
+    if not self.components.required_args:
+        return None
+    else:
+        return [arg.GetValue() for arg in self.components.required_args]
 
   def GetOptionalArgs(self):
-    return [arg.GetValue() for arg in
+    if not self.components.general_args:
+        return None
+    else:
+        return [arg.GetValue() for arg in
             chain(self.components.general_options, self.components.flags)]
 
 

--- a/gooey/python_bindings/gooey_decorator.py
+++ b/gooey/python_bindings/gooey_decorator.py
@@ -165,7 +165,7 @@ def get_caller_path():
   return tmp_sys.argv[0]
 
 def has_argparse(source):
-  bla = ['.parse_args()' in line.lower() for line in source.split('\n')]
+  bla = ['.parse_args(' in line.lower() for line in source.split('\n')]
   return any(bla)
 
 def cleanup(descriptor, filepath):


### PR DESCRIPTION
Various fixes to make Gooey more usable. Some changes were necessary to make Gooey work with my script (which supplies a custom argv to argparse).

I also added an entry in the README about a small snippet called "AutoGooey decorator" so that an application can both be used with Gooey and without.

A more elegant solution would be to provide this functionality in Gooey itself, as an additional argument of the gooey.Gooey() decorator function:

    def Gooey(f=None, advanced=True,
            language='english', show_config=True,
            program_name=None, program_description=None,
            enable_on=None):

        if enable_on and len(sys.argv) > 1 and sys.argv[1] != enable_on:
            return f
        else: # Avoid infinite recursion calls to Gooey decorator by replacing the enable_on argument
            sys.argv[1] = sys.argv[1] + "_done"
        # ... rest of the decorator ...

This would for example allow to use @Gooey(enable_on="--gui") to enable the decorator only when --gui is given as an argument.
