### PR TITLE
Small typo in code example, fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Given then above, Gooey would select a normal `TextField` as the widget type lik
 However, by dropping in `GooeyParser` and supplying a `widget` name, you display a much more user friendly `FileChooser` 
 
 
-    from gooeyimport GooeyParser
+    from gooey import GooeyParser
     ....
     
     def main(): 


### PR DESCRIPTION
This is a trivial change, but for users trying out new code there shouldn't be any syntax errors in the examples.