### PR TITLE
Multi dir dialog

### DIFF
--- a/gooey/gui/widgets/components.py
+++ b/gooey/gui/widgets/components.py
@@ -232,4 +232,6 @@ DateChooser       = lambda data: BaseGuiComponent(data=data, widget_pack=widget_
 TextField         = lambda data: BaseGuiComponent(data=data, widget_pack=widget_pack.TextInputPayload())
 Dropdown          = lambda data: BaseGuiComponent(data=data, widget_pack=widget_pack.DropdownPayload())
 Counter           = lambda data: BaseGuiComponent(data=data, widget_pack=widget_pack.CounterPayload())
+MultiDirChooser   = lambda data: BaseGuiComponent(data=data, widget_pack=widget_pack.MultiDirChooserPayload())
+
 

--- a/gooey/gui/widgets/widget_pack.py
+++ b/gooey/gui/widgets/widget_pack.py
@@ -93,7 +93,6 @@ class BaseFileChooser(BaseChooser):
       self.text_box.SetValue(result)
 
   def get_path(self, dlg):
-    print("In get_path")
     if isinstance(dlg, wx.DirDialog):
       return dlg.GetPath()
     else:

--- a/gooey/gui/widgets/widget_pack.py
+++ b/gooey/gui/widgets/widget_pack.py
@@ -93,51 +93,12 @@ class BaseFileChooser(BaseChooser):
       self.text_box.SetValue(result)
 
   def get_path(self, dlg):
+    print("In get_path")
     if isinstance(dlg, wx.DirDialog):
       return dlg.GetPath()
     else:
       paths = dlg.GetPaths()
       return paths[0] if len(paths) < 2 else ' '.join(paths)
-
-
-def correctPath(path): # This had to be made because it was returning a weird ass Path looking like : Local Disk (C:)/Users/..../Folder
-  tab = path.split('\\')
-  disk = re.split("[()]", tab[0])[1]
-  tab.pop(0)
-  for line in tab:
-    disk += u"/" + line
-  return (disk)
-
-def correctPaths(myList): # Cf correctPath
-  newList = []
-  for field in myList:
-    if not os.path.exists(field): # If it returns a "Local Disk (C:)/.../Folder" Bullshit.
-      newList.append(correctPath(field))
-    else:
-      newList.append(field)
-  return (newList)
-
-
-
-class BaseMultiDirChooser(BaseChooser): # kind of just copied yours.
-  def __init__(self, dialog): # Same code here normally.
-    BaseChooser.__init__(self)
-    self.dialog = dialog
-
-  def onButton(self, evt):
-    dlg = self.dialog(self.parent)
-    result = (dlg.GetPaths()
-              if dlg.ShowModal() == wx.ID_OK
-              else None)
-    res = correctPaths(result)
-    res = self.get_path(res)
-    if res:
-      # self.text_box references a field on the class this is passed into
-      # kinda hacky, but avoided a buncha boilerplate
-      self.text_box.SetValue(res)
-  def get_path(self, cleanList):
-    paths = cleanList
-    return paths[0] if len(paths) < 2 else ';'.join(paths)
 
 def build_dialog(style, exist_constraint=True, **kwargs):
   if exist_constraint:
@@ -151,7 +112,7 @@ FileSaverPayload      = partial(BaseFileChooser, dialog=build_dialog(wx.FD_SAVE,
 MultiFileSaverPayload = partial(BaseFileChooser, dialog=build_dialog(wx.FD_MULTIPLE, False))
 DirChooserPayload     = partial(BaseFileChooser, dialog=lambda parent: wx.DirDialog(parent, 'Select Directory', style=wx.DD_DEFAULT_STYLE))
 DateChooserPayload    = partial(BaseFileChooser, dialog=CalendarDlg)
-MultiDirChooserPayload  = partial(BaseMultiDirChooser, dialog=lambda parent: MDD.MultiDirDialog(parent, 'Select Directories', defaultPath=os.getcwd(), agwStyle=MDD.DD_MULTIPLE|MDD.DD_DIR_MUST_EXIST))
+MultiDirChooserPayload = partial(BaseFileChooser, dialog=lambda parent: wx.DirDialog(parent, 'Select Directory', style=wx.DD_DEFAULT_STYLE | wx.DIRCTRL_MULTIPLE))
 
 class TextInputPayload(WidgetPack):
   def __init__(self):

--- a/gooey/gui/widgets/widget_pack.py
+++ b/gooey/gui/widgets/widget_pack.py
@@ -7,6 +7,7 @@ __author__ = 'Chris'
 from abc import ABCMeta, abstractmethod
 
 import wx
+import os
 import wx.lib.agw.multidirdialog as MDD
 
 from gooey.gui.widgets.calender_dialog import CalendarDlg

--- a/gooey/gui/widgets/widget_pack.py
+++ b/gooey/gui/widgets/widget_pack.py
@@ -8,6 +8,7 @@ from abc import ABCMeta, abstractmethod
 
 import wx
 import os
+import re
 import wx.lib.agw.multidirdialog as MDD
 
 from gooey.gui.widgets.calender_dialog import CalendarDlg

--- a/gooey/gui/widgets/widget_pack.py
+++ b/gooey/gui/widgets/widget_pack.py
@@ -102,7 +102,7 @@ class BaseFileChooser(BaseChooser):
 
 def correctPath(path): # This had to be made because it was returning a weird ass Path looking like : Local Disk (C:)/Users/..../Folder
   tab = path.split('\\')
-  disk = re.split("[()]", tmpTab)[1]
+  disk = re.split("[()]", tab[0])[1]
   tab.pop(0)
   for line in tab:
     disk += u"/" + line

--- a/gooey/gui/widgets/widget_pack.py
+++ b/gooey/gui/widgets/widget_pack.py
@@ -7,9 +7,6 @@ __author__ = 'Chris'
 from abc import ABCMeta, abstractmethod
 
 import wx
-import os
-import re
-import wx.lib.agw.multidirdialog as MDD
 
 from gooey.gui.widgets.calender_dialog import CalendarDlg
 

--- a/gooey/python_bindings/argparse_to_json.py
+++ b/gooey/python_bindings/argparse_to_json.py
@@ -24,7 +24,8 @@ VALID_WIDGETS = (
   'Dropdown',
   'Counter',
   'RadioGroup',
-  'CheckBox'
+  'CheckBox',
+  'MultiDirChooser'
 )
 
 


### PR DESCRIPTION
Hello, 
So, i appreciated a lot this nifty little module and also wanted something like this for a while now but couldnt find a simple, neatly packaged module. Gooey is the one!

I had a go at trying to implement a multiDirDialog. So it is functionnal, up to you if you wish to have it or not and if you find a better way of implementing it. :-)

Used the `MultiDirDialog` from wx.lib.agw and chucked in some formatting of the return value (For some weird reason it explicitly states that it is a `"Local Disk (C:)"` Instead of just `"C:"` when returning the path)

Anyhow, i'm also relatively new to actually doing something with a project (I.e putting it online so other people can glitch and not only you!) So if there are any procedures to be done before this pull request is created, sorry, I probably did not do it. (Other than testing a few cases.)

Please, just don't have a weird username like on one of my machines (ðø/any unicode type of characters don't pass well.) and it shouldn't have a problem.

Only three issues i can think about are : 
1 - The weird format of the path when MDD returns. I.E : `"Local Disk (C:)/Users/User/Documents"`
2 - If you happen to have accents/unicode characters in your username/Directory names, it freaks out at `return '{0} "{1}"'.format(self.option_string, value)`
3 - If you happen to manage to select a non existing directory (Shouldn't be possible but if you decide to remove the `MDD.DD_DIR_MUST_EXIST` it will be), AND that directory is somehow not created with the MDD dialog (If you play around with that code too) AND the error message stating `the directory does not exist` contains accents on your system, it will freak out due to unicode at `i18n._('uh_oh').format(error_msg)`