### PR TITLE
Make checkbox labels clickable

### DIFF
--- a/gooey/gui/widgets/components.py
+++ b/gooey/gui/widgets/components.py
@@ -124,6 +124,8 @@ class CheckBox(BaseGuiComponent):
     self.help_msg = self.createHelpMsgWidget(self.panel)
     self.help_msg.SetMinSize((0, -1))
 
+    self.help_msg.Bind(wx.EVT_LEFT_UP, lambda event: self.widget.SetValue(not self.widget.GetValue()))
+
     vertical_container = wx.BoxSizer(wx.VERTICAL)
     vertical_container.Add(self.title)
 


### PR DESCRIPTION
On a native Windows GUI checkbox labels are clickable.
The change makes a checkbox to change its state when the label next to it is clicked.