### PR TITLE
Don't pass frozen programs to python.

### DIFF
--- a/gooey/python_bindings/config_generator.py
+++ b/gooey/python_bindings/config_generator.py
@@ -8,7 +8,11 @@ from gooey.python_bindings import source_parser
 def create_from_parser(parser, source_path, **kwargs):
   show_config = kwargs.get('show_config', False)
 
-  run_cmd = 'python {}'.format(source_path)
+  #If script has been frozen execute it straight
+  if hasattr(sys, 'frozen'):
+    run_cmd = source_path
+  else:
+    run_cmd = 'python {}'.format(source_path)
 
   build_spec = {
     'language':             kwargs.get('language', 'english'),


### PR DESCRIPTION
Fixes part of #58 (thanks to @daranguiz for this solution).

If a script has been frozen, Gooey should run the executable as-is instead of trying to pass it to Python. This should work with most if not all Python "freezing" solutions, specifically PyInstaller and newer versions of Py2exe which both have a frozen attribute in sys.