### PR TITLE
Correctly use the subparser widgets dictionary

### DIFF
--- a/gooey/python_bindings/argparse_to_json.py
+++ b/gooey/python_bindings/argparse_to_json.py
@@ -45,7 +45,8 @@ def convert(parser):
     if has_required(actions):
       raise UnsupportedConfiguration("Gooey doesn't currently support required arguments when subparsers are present.")
     layout_type = 'column'
-    layout_data = {name.lower(): process(sub_parser, widget_dict) for name, sub_parser in get_subparser(actions).choices.iteritems()}
+    layout_data = {name.lower(): process(sub_parser, getattr(sub_parser, 'widgets', {}))
+                   for name, sub_parser in get_subparser(actions).choices.iteritems()}
   else:
     layout_type = 'standard'
     layout_data = process(parser, widget_dict)


### PR DESCRIPTION
When generating the GUI using subparsers, the subparser widgets dictionary is used instead of the parent one. (Issue #112)

The parser:

        parser = GooeyParser(description="example")
        parser.add_argument("dir", help="directory", widget="DirChooser")

produces the following output when passed to the function `gooey.python_bindings.argparse_to_json.convert`:

    {'widgets': [{'data': {'commands': [], 'display_name': 'dir', 'help': 'directory', 'default': None, 'nargs': '', 'choices': []}, 'required': True, 'type': 'DirChooser'}], 'layout_type': 'standard'}

As you can see the widget `DirChooser` is correctly selected.

When using a subparser instead:

    parser = GooeyParser(description='example')
    subs = parser.add_subparsers()
    sub = subs.add_parser("sub")
    sub.add_argument("dir", help="directory", widget="DirChooser")

The conversion is:

    {'widgets': {'sub': [{'data': {'commands': [], 'display_name': 'dir', 'help': 'directory', 'default': None, 'nargs': '', 'choices': []}, 'required': True, 'type': 'TextField'}]}, 'layout_type': 'column'} 

So the `TextField` type is selected instead of the requested `DirChooser`.

This happens because in the `convert` function, the parent widget dictionary is used even when checking for the subparser elements:

    def convert(parser):
      widget_dict = getattr(parser, 'widgets', {})
      ...

      if has_subparsers(actions):
        ...
        layout_data = {name.lower(): process(sub_parser, widget_dict) for name, sub_parser in get_subparser(actions).choices.iteritems()}
        ...

So I replaced `widget_dict` with `getattr(sub_parser, 'widgets', {})` to get the subparser dictionary.

If for some reason you think that the parent widget dictionary is needed by the subparser, we may merge the two dictionary, but I think it is not needed.