### PR TITLE
Option to load previously generated configuration in the Gooey decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,9 @@ Different styling and functionality can be configured by passing arguments into 
            default_size=(610, 530),   # starting size of the GUI
            required_cols=1,           # number of columns in the "Required" section
            optional_cols=2,           # number of columbs in the "Optional" section
-           dump_build_config=False)   # Dump the JSON Gooey uses to configure itself
+           dump_build_config=False,   # Dump the JSON Gooey uses to configure itself
+           load_build_config=None,    # Loads a JSON Gooey-generated configuration
+           monospace_display=False)   # Uses a mono-spaced font in the output screen
     )
     def main():
       parser = ArgumentParser(...)
@@ -249,6 +251,8 @@ Just about everything in Gooey can be customized by passing arguments to the dec
 | required_cols | Controls how many columns are in the Required Arguments section |
 | optional_cols | Controls how many columns are in the Optional Arguments section |
 | dump_build_config | Saves a `json` copy of its build configuration on disk for reuse/editing | 
+| load_build_config | Loads a `json` copy of its build configuration from disk | 
+| monospace_display | Uses a mono-spaced font in the output screen | 
 
 
 

--- a/gooey/python_bindings/gooey_decorator.py
+++ b/gooey/python_bindings/gooey_decorator.py
@@ -51,6 +51,7 @@ def Gooey(f=None,
           build_spec = json.load(open(load_build_config, "r"))
         except Exception, e:
           print( 'Exception loading Build Config from {0}: {1}'.format(load_build_config, e))
+          sys.exit(1)
 
       if not build_spec:
         build_spec = config_generator.create_from_parser(self, source_path, payload_name=payload.__name__, **params)

--- a/gooey/python_bindings/gooey_decorator.py
+++ b/gooey/python_bindings/gooey_decorator.py
@@ -32,6 +32,7 @@ def Gooey(f=None,
           required_cols=2,
           optional_cols=2,
           dump_build_config=False,
+          load_build_config=None,
           monospace_display=False):
   '''
   Decorator for client code's main function.
@@ -43,7 +44,16 @@ def Gooey(f=None,
   def build(payload):
     def run_gooey(self, args=None, namespace=None):
       source_path = sys.argv[0]
-      build_spec = config_generator.create_from_parser(self, source_path, payload_name=payload.__name__, **params)
+
+      build_spec = None
+      if load_build_config:
+        try:
+          build_spec = json.load(open(load_build_config, "r"))
+        except Exception, e:
+          print( 'Exception loading Build Config from {0}: {1}'.format(load_build_config, e))
+
+      if not build_spec:
+        build_spec = config_generator.create_from_parser(self, source_path, payload_name=payload.__name__, **params)
 
       if dump_build_config:
         config_path = os.path.join(os.getcwd(), 'gooey_config.json')


### PR DESCRIPTION
Option to load previously generated configuration using the Gooey decorator. New load_build_config parameter added.

This makes it easy to dump the configuration, and do some tweaking to use it later, if needed.