### PR TITLE
Separate boxes used to input command line parts and other data

### DIFF
--- a/gooey/gui/util/quoting.py
+++ b/gooey/gui/util/quoting.py
@@ -7,7 +7,3 @@ if sys.platform.startswith("win"):
 else:  # POSIX shell
   def quote(value):
     return "'{}'".format('{}'.format(value).replace("'", "'\\''"))
-
-
-def maybe_quote(string):
-  return '"{}"'.format(string) if not re.match(r'^".*"$', string) else string

--- a/gooey/gui/widgets/components.py
+++ b/gooey/gui/widgets/components.py
@@ -234,6 +234,7 @@ DirChooser        = lambda data: BaseGuiComponent(data=data, widget_pack=widget_
 FileSaver         = lambda data: BaseGuiComponent(data=data, widget_pack=widget_pack.FileSaverPayload())
 DateChooser       = lambda data: BaseGuiComponent(data=data, widget_pack=widget_pack.DateChooserPayload())
 TextField         = lambda data: BaseGuiComponent(data=data, widget_pack=widget_pack.TextInputPayload())
+CommandField      = lambda data: BaseGuiComponent(data=data, widget_pack=widget_pack.TextInputPayload(no_qouting=True))
 Dropdown          = lambda data: BaseGuiComponent(data=data, widget_pack=widget_pack.DropdownPayload())
 Counter           = lambda data: BaseGuiComponent(data=data, widget_pack=widget_pack.CounterPayload())
 MultiDirChooser   = lambda data: BaseGuiComponent(data=data, widget_pack=widget_pack.MultiDirChooserPayload())

--- a/gooey/gui/widgets/components.py
+++ b/gooey/gui/widgets/components.py
@@ -97,6 +97,9 @@ class BaseGuiComponent(object):
   def GetValue(self):
     return self.widget_pack.getValue()
 
+  def HasOptionString(self):
+    return bool(self.widget_pack.option_string)
+
   def _GetWidget(self):
     # used only for unittesting
     return self.widget_pack.widget
@@ -157,6 +160,9 @@ class CheckBox(BaseGuiComponent):
   def GetValue(self):
     return self.option_strings if self.widget.GetValue() else ''
 
+  def HasOptionString(self):
+    return bool(self.option_strings)
+
   def _GetWidget(self):
     return self.widget
 
@@ -168,7 +174,7 @@ class RadioGroup(object):
     self.data = data
 
     self.radio_buttons = []
-    self.option_stings = []
+    self.option_strings = []
     self.help_msgs = []
     self.btn_names = []
 
@@ -181,7 +187,7 @@ class RadioGroup(object):
     self.radio_buttons = [wx.RadioButton(self.panel, -1) for _ in self.data]
     self.btn_names = [wx.StaticText(self.panel, label=btn_data['display_name'].title()) for btn_data in self.data]
     self.help_msgs = [wx.StaticText(self.panel, label=btn_data['help'].title()) for btn_data in self.data]
-    self.option_stings = [btn_data['commands'] for btn_data in self.data]
+    self.option_strings = [btn_data['commands'] for btn_data in self.data]
 
     # box = wx.StaticBox(self.panel, -1, label=self.data['group_name'])
     box = wx.StaticBox(self.panel, -1, label='')
@@ -223,6 +229,9 @@ class RadioGroup(object):
       return self.option_strings[vals.index(True)][0]
     except:
       return ''
+
+  def HasOptionString(self):
+    return bool(self.option_strings)
 
   def _GetWidget(self):
     return self.radio_buttons

--- a/gooey/gui/widgets/components.py
+++ b/gooey/gui/widgets/components.py
@@ -145,7 +145,7 @@ class CheckBox(BaseGuiComponent):
     return self.panel
 
   def onSetter(self, evt):
-    self.getValue()
+    self.GetValue()
 
   def onResize(self, evt):
     msg = self.help_msg
@@ -211,7 +211,7 @@ class RadioGroup(object):
     return self.panel
 
   def onSetter(self, evt):
-    self.getValue()
+    self.GetValue()
 
   def onResize(self, evt):
     msg = self.help_msgs[0]

--- a/gooey/gui/widgets/widget_pack.py
+++ b/gooey/gui/widgets/widget_pack.py
@@ -111,20 +111,12 @@ class BaseMultiFileChooser(BaseFileChooser):
       return '{} {}'.format(self.option_string, value)
     return value or ''
 
-  def onButton(self, evt):
-    dlg = self.dialog(self.parent)
-    result = (self.get_path(dlg)
-              if dlg.ShowModal() == wx.ID_OK
-              else None)
-    if result:
-      self.text_box.SetValue(result)
-
   def get_path(self, dlg):
     return os.pathsep.join(dlg.GetPaths())
 
 
 class MyMultiDirChooser(MDD.MultiDirDialog):
-  def __init(self, *args, **kwargs):
+  def __init__(self, *args, **kwargs):
     super(MyMultiDirChooser, self).__init__(*args, **kwargs)
 
   def GetPaths(self):

--- a/gooey/gui/widgets/widget_pack.py
+++ b/gooey/gui/widgets/widget_pack.py
@@ -47,9 +47,9 @@ class BaseChooser(WidgetPack):
     self.text_box = None
     self.button = None
 
-  def build(self, parent, data=None):
+  def build(self, parent, data):
     self.parent = parent
-    self.option_string = data['commands'][0] if data['commands'] else ''
+    self.option_string = self.get_command(data)
     self.text_box = wx.TextCtrl(self.parent)
     self.text_box.AppendText(safe_default(data, ''))
     self.text_box.SetMinSize((0, -1))
@@ -166,7 +166,7 @@ class TextInputPayload(WidgetPack):
     if self.no_quoting:
       _quote = lambda value: value
     else:
-      _quote = lambda value: quote(value)
+      _quote = quote
     value = self.widget.GetValue()
     if value and self.option_string:
       return '{} {}'.format(self.option_string, _quote(value))
@@ -242,4 +242,4 @@ class CounterPayload(WidgetPack):
 
 def safe_default(data, default):
   # str(None) is 'None'!? Whaaaaat...?
-  return str(data['default']) if data['default'] else ''
+  return str(data['default']) if data['default'] else default

--- a/gooey/gui/windows/advanced_config.py
+++ b/gooey/gui/windows/advanced_config.py
@@ -93,10 +93,12 @@ class ConfigPanel(ScrolledPanel, OptionReader):
     """
     returns the collective values from all of the
     widgets contained in the panel"""
-    values = [c.GetValue()
-              for c in chain(*self.widgets)
-              if c.GetValue() is not None]
-    return ' '.join(values)
+    _f = lambda lst: [x for x in lst if x is not None]
+    optional_args = _f([c.GetValue() for c in self.widgets.optional_args])
+    required_args = _f([c.GetValue() for c in self.widgets.required_args if c.HasOptionString()])
+    position_args = _f([c.GetValue() for c in self.widgets.required_args if not c.HasOptionString()])
+    if position_args: position_args.insert(0, "--")
+    return ' '.join(chain(required_args, optional_args, position_args))
 
   def GetRequiredArgs(self):
     return [arg.GetValue() for arg in self.widgets.required_args]

--- a/gooey/gui/windows/layouts.py
+++ b/gooey/gui/windows/layouts.py
@@ -9,7 +9,7 @@ from gooey.gui.util import wx_util
 
 basic_config = {
     'required': [{
-      'type': 'TextField',
+      'type': 'CommandField',
       'data': {
         'display_name': 'Enter Commands',
         'help': 'Enter command line arguments',

--- a/gooey/gui/windows/layouts.py
+++ b/gooey/gui/windows/layouts.py
@@ -6,6 +6,8 @@ from gooey.gui import events
 from gooey.gui.windows.advanced_config import ConfigPanel
 from gooey.gui.windows.sidebar import Sidebar
 from gooey.gui.util import wx_util
+from gooey.gui.util.quoting import quote
+
 
 basic_config = {
     'required': [{
@@ -77,7 +79,7 @@ class ColumnLayout(wx.Panel):
     return panels
 
   def GetOptions(self):
-    return '{} {}'.format(self.active_panel, self.config_panels[self.active_panel].GetOptions())
+    return '{} {}'.format(quote(self.active_panel), self.config_panels[self.active_panel].GetOptions())
 
   def GetRequiredArgs(self):
     return self.config_panels[self.active_panel].GetRequiredArgs()

--- a/gooey/python_bindings/argparse_to_json.py
+++ b/gooey/python_bindings/argparse_to_json.py
@@ -85,7 +85,7 @@ def categorize(actions, widget_dict, required=False):
     elif is_flag(action):
       yield as_json(action, _get_widget(action) or 'CheckBox', required)
     elif is_counter(action):
-      _json = as_json(action, _get_widget(action) or 'Dropdown', required)
+      _json = as_json(action, _get_widget(action) or 'Counter', required)
       # pre-fill the 'counter' dropdown
       _json['data']['choices'] = map(str, range(1, 11))
       yield _json


### PR DESCRIPTION
Strongly separate input boxes used to data and command line input boxes.
MultiDirChooser and other similar Payloads store not a part of a command but a list of paths separated by a os dependend path separator. Also POSIX shell quoting added but untested.
This pull request contains https://github.com/chriskiehl/Gooey/pull/118