### PR TITLE
quoting unicode bug

### DIFF
--- a/gooey/gui/util/quoting.py
+++ b/gooey/gui/util/quoting.py
@@ -2,4 +2,4 @@ import re
 
 
 def maybe_quote(string):
-  return '"{}"'.format(string) if not re.match(r'^".*"$', string) else string
+  return u'"{}"'.format(string) if not re.match(r'^".*"$', string) else string


### PR DESCRIPTION
I think this is a bug in "gooey/qui/util/quoting.py". If try to choose some russian named directory appear this  ascii error:

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/Gooey-0.8.12.0-py2.7.egg/gooey/gui/widgets/widget_pack.py", line 92, in onButton
    if dlg.ShowModal() == wx.ID_OK
  File "/usr/local/lib/python2.7/dist-packages/Gooey-0.8.12.0-py2.7.egg/gooey/gui/widgets/widget_pack.py", line 99, in get_path
    return maybe_quote(dlg.GetPath())
  File "/usr/local/lib/python2.7/dist-packages/Gooey-0.8.12.0-py2.7.egg/gooey/gui/util/quoting.py", line 5, in maybe_quote
    return '"{}"'.format(string) if not re.match(r'^".*"$', string) else string
UnicodeEncodeError: 'ascii' codec can't encode characters in position 12-20: ordinal not in range(128)


```