### PR TITLE
pyinstaller --onefile support (#58)

### DIFF
--- a/gooey/gui/util/freeze.py
+++ b/gooey/gui/util/freeze.py
@@ -8,13 +8,17 @@ def is_frozen():
 
 def get_resource_path(*args):
   if is_frozen():
-    resource_dir = os.path.join(os.path.dirname(sys.executable), 'gooey')
+    basedir = getattr(sys, '_MEIPASS', None)
+    if not basedir:
+      basedir = os.path.dirname(sys.executable)
+    resource_dir = os.path.join(basedir, 'gooey')
     if not os.path.isdir(resource_dir):
-      raise IOError(("cannot locate Gooey resources. It seems that the program "
-                     "was frozen, but resource files were not copied to "
-                     "directory of the executable file. Please copy "
-                     "`languages` and `images` folders from gooey module "
-                     "directory into `{}{}` directory.".format(resource_dir, os.sep)))
+      raise IOError(
+        ("Cannot locate Gooey resources. It seems that the program was frozen, "
+         "but resource files were not copied into directory of the executable "
+         "file. Please copy `languages` and `images` folders from gooey module "
+         "directory into `{}{}` directory. Using PyInstaller, a.datas in .spec "
+         "file must be specified.".format(resource_dir, os.sep)))
   else:
     resource_dir = os.path.normpath(os.path.join(os.path.dirname(__file__), '..', '..'))
   return os.path.join(resource_dir, *args)


### PR DESCRIPTION
This should work with pyinstaller --onefile. Note that `a.datas` in `.spec` file must be specified.
```python
a = Analysis(
             ...
             datas=[('C:\\path\\to\\gooey\\images\\*.png', 'gooey\\images'),
                    ('C:\\path\\to\\gooey\\images\\*.ico', 'gooey\\images'),
                    ('C:\\path\\to\\gooey\\languages\\*.json', 'gooey\\languages')],
            ...
```