### PR TITLE
Make tests pass, close #127.

### DIFF
--- a/gooey/tests/argparse_to_json_unittest.py
+++ b/gooey/tests/argparse_to_json_unittest.py
@@ -148,7 +148,7 @@ def test_is_counter(empty_parser):
 
 def test_mutually(exclusive_group):
   target_arg = find_arg_by_option(exclusive_group, '-i')
-  json_result = build_radio_group(exclusive_group)[0]
+  json_result = build_radio_group(exclusive_group)
 
   data = json_result['data'][0]
   assert 'RadioGroup' == json_result['type']


### PR DESCRIPTION
build_radio_group() started returning results not wrapped
in a list in 8103314, change the test to reflect that.