### PR TITLE
More tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,10 @@ pip-log.txt
 
 # Unit test / coverage reports
 .coverage
+htmlcov
 .tox
 nosetests.xml
+.cache
 
 # Translations
 *.mo

--- a/gooey/python_bindings/config_generator.py
+++ b/gooey/python_bindings/config_generator.py
@@ -41,8 +41,3 @@ def create_from_parser(parser, source_path, **kwargs):
     build_spec['manual_start'] = True
 
   return build_spec
-
-
-
-def has_argparse(module_path):
-  return any(['.parse_args(' in line.lower() for line in f.readlines()])

--- a/gooey/tests/argparse_to_json_unittest.py
+++ b/gooey/tests/argparse_to_json_unittest.py
@@ -2,66 +2,6 @@ import pytest
 from gooey.python_bindings.argparse_to_json import *
 
 
-@pytest.fixture
-def empty_parser():
-  return argparse.ArgumentParser(description='description')
-
-@pytest.fixture
-def complete_parser():
-  parser = argparse.ArgumentParser(description='description')
-  parser.add_argument("req1", help='filename help msg')  # positional
-  parser.add_argument("req2", help="Name of the file where you'll save the output")  # positional
-  parser.add_argument('-r',   dest="req3", default=10, type=int, help='sets the time to count down from', required=True)
-  parser.add_argument('--req4', dest="req4", default=10, type=int, help='sets the time to count down from', required=True)
-
-  parser.add_argument("-a", "--aa", action="store_true", help="aaa")
-  parser.add_argument("-b", "--bb", action="store_true", help="bbb")
-  parser.add_argument('-c', '--cc', action='count')
-  parser.add_argument("-d", "--dd", action="store_true", help="ddd")
-  parser.add_argument('-e', '--ee', choices=['yes', 'no'], help='eee')
-  parser.add_argument("-f", "--ff", default="0000", help="fff")
-  parser.add_argument("-g", "--gg", action="store_true", help="ggg")
-  verbosity = parser.add_mutually_exclusive_group()
-  verbosity.add_argument('-i', '--ii', action="store_true", help="iii")
-  verbosity.add_argument('-j', '--jj', action="store_true", help="hhh")
-  return parser
-
-@pytest.fixture
-def subparser():
-  parser = argparse.ArgumentParser(description='qidev')
-  parser.add_argument('--verbose', help='be verbose', dest='verbose', action='store_true', default=False)
-  subs = parser.add_subparsers(help='commands', dest='command')
-
-  config_parser = subs.add_parser('config', help='configure defaults for qidev')
-  config_parser.add_argument('field', help='the field to configure', type=str)
-  config_parser.add_argument('value', help='set field to value', type=str)
-
-  # ########################################################
-  connect_parser = subs.add_parser('connect', help='connect to a robot (ip/hostname)')
-  connect_parser.add_argument('hostname', help='hostname or IP address of the robot', type=str)
-
-  # ########################################################
-  install_parser = subs.add_parser('install', help='package and install a project directory on a robot')
-  install_parser.add_argument('path', help='path to the project directory (containing manifest.xml', type=str)
-  install_parser.add_argument('--ip', nargs='*', type=str, dest='ip', help='specify hostname(es)/IP address(es)')
-  return parser
-
-
-@pytest.fixture
-def exclusive_group():
-  parser = argparse.ArgumentParser(description='description')
-  verbosity = parser.add_mutually_exclusive_group()
-  verbosity.add_argument('-i', dest="option1", action="store_true", help="iii")
-  verbosity.add_argument('-j', dest="option2", action="store_true", help="hhh")
-
-  mutually_exclusive_group = [mutex_action
-                              for group_actions in parser._mutually_exclusive_groups
-                              for mutex_action in group_actions._group_actions]
-  return mutually_exclusive_group
-
-
-
-
 def test_parser_converts_to_correct_type(empty_parser, complete_parser, subparser):
   assert convert(subparser)['layout_type'] == 'column'
   assert convert(empty_parser)['layout_type'] == 'standard'

--- a/gooey/tests/argparse_to_json_unittest.py
+++ b/gooey/tests/argparse_to_json_unittest.py
@@ -148,7 +148,7 @@ def test_is_counter(empty_parser):
 
 def test_mutually(exclusive_group):
   target_arg = find_arg_by_option(exclusive_group, '-i')
-  json_result = build_radio_group(exclusive_group)[0]
+  json_result = build_radio_group(exclusive_group)
 
   data = json_result['data'][0]
   assert 'RadioGroup' == json_result['type']

--- a/gooey/tests/argparse_to_json_unittest.py
+++ b/gooey/tests/argparse_to_json_unittest.py
@@ -158,6 +158,15 @@ def test_mutually(exclusive_group):
   assert target_arg.dest == data['display_name']
 
 
+def test_empty_mutex_group():
+  assert not build_radio_group(None)
+
+
+def test_as_json_invalid_widget():
+  with pytest.raises(UnknownWidgetType):
+    as_json(None, 'InvalidWidget', None)
+
+
 def get_action(parser, dest):
   for action in parser._actions:
     if action.dest == dest:
@@ -168,11 +177,3 @@ def find_arg_by_option(group, option_string):
   for arg in group:
     if option_string in arg.option_strings:
       return arg
-
-
-
-
-
-
-
-

--- a/gooey/tests/config_generator_unittest.py
+++ b/gooey/tests/config_generator_unittest.py
@@ -1,11 +1,4 @@
-import argparse
-import pytest
 from gooey.python_bindings.config_generator import *
-
-# TODO: duplicated from argparse_to_json_unittest, should go into conftest.py
-@pytest.fixture
-def empty_parser():
-  return argparse.ArgumentParser(description='description')
 
 
 def test_create_from_parser(empty_parser):

--- a/gooey/tests/config_generator_unittest.py
+++ b/gooey/tests/config_generator_unittest.py
@@ -1,0 +1,20 @@
+import argparse
+import pytest
+from gooey.python_bindings.config_generator import *
+
+# TODO: duplicated from argparse_to_json_unittest, should go into conftest.py
+@pytest.fixture
+def empty_parser():
+  return argparse.ArgumentParser(description='description')
+
+
+def test_create_from_parser(empty_parser):
+  build_spec = create_from_parser(empty_parser,'.')
+  assert build_spec['manual_start'] == True
+
+
+def test_create_from_parser_show_config(empty_parser):
+  build_spec = create_from_parser(empty_parser,
+                                  '.',
+                                  show_config=True)
+  assert build_spec['program_description'] == 'description'

--- a/gooey/tests/conftest.py
+++ b/gooey/tests/conftest.py
@@ -1,0 +1,67 @@
+import argparse
+import pytest
+
+@pytest.fixture
+def empty_parser():
+  return argparse.ArgumentParser(description='description')
+
+
+@pytest.fixture
+def complete_parser():
+  parser = argparse.ArgumentParser(description='description')
+  parser.add_argument("req1", help='filename help msg')  # positional
+  parser.add_argument("req2", help="Name of the file where you'll save the output")  # positional
+  parser.add_argument('-r',   dest="req3", default=10, type=int, help='sets the time to count down from', required=True)
+  parser.add_argument('--req4', dest="req4", default=10, type=int, help='sets the time to count down from', required=True)
+
+  parser.add_argument("-a", "--aa", action="store_true", help="aaa")
+  parser.add_argument("-b", "--bb", action="store_true", help="bbb")
+  parser.add_argument('-c', '--cc', action='count')
+  parser.add_argument("-d", "--dd", action="store_true", help="ddd")
+  parser.add_argument('-e', '--ee', choices=['yes', 'no'], help='eee')
+  parser.add_argument("-f", "--ff", default="0000", help="fff")
+  parser.add_argument("-g", "--gg", action="store_true", help="ggg")
+  verbosity = parser.add_mutually_exclusive_group()
+  verbosity.add_argument('-i', '--ii', action="store_true", help="iii")
+  verbosity.add_argument('-j', '--jj', action="store_true", help="hhh")
+  return parser
+
+
+@pytest.fixture
+def subparser():
+  parser = argparse.ArgumentParser(description='qidev')
+  parser.add_argument('--verbose', help='be verbose', dest='verbose', action='store_true', default=False)
+  subs = parser.add_subparsers(help='commands', dest='command')
+
+  config_parser = subs.add_parser('config', help='configure defaults for qidev')
+  config_parser.add_argument('field', help='the field to configure', type=str)
+  config_parser.add_argument('value', help='set field to value', type=str)
+
+  # ########################################################
+  connect_parser = subs.add_parser('connect', help='connect to a robot (ip/hostname)')
+  connect_parser.add_argument('hostname', help='hostname or IP address of the robot', type=str)
+
+  # ########################################################
+  install_parser = subs.add_parser('install', help='package and install a project directory on a robot')
+  install_parser.add_argument('path', help='path to the project directory (containing manifest.xml', type=str)
+  install_parser.add_argument('--ip', nargs='*', type=str, dest='ip', help='specify hostname(es)/IP address(es)')
+  return parser
+
+
+@pytest.fixture
+def exclusive_group():
+  parser = argparse.ArgumentParser(description='description')
+  verbosity = parser.add_mutually_exclusive_group()
+  verbosity.add_argument('-i', dest="option1", action="store_true", help="iii")
+  verbosity.add_argument('-j', dest="option2", action="store_true", help="hhh")
+
+  mutually_exclusive_group = [mutex_action
+                              for group_actions in parser._mutually_exclusive_groups
+                              for mutex_action in group_actions._group_actions]
+  return mutually_exclusive_group
+
+
+@pytest.fixture
+def expected_attrs():
+  return ('program_icon', 'success_icon', 'running_icon',
+          'loading_icon', 'config_icon', 'error_icon')

--- a/gooey/tests/image_repositoy_unittest.py
+++ b/gooey/tests/image_repositoy_unittest.py
@@ -6,12 +6,6 @@ import pytest
 import tempfile
 
 
-@pytest.fixture
-def expected_attrs():
-  return ('program_icon', 'success_icon', 'running_icon',
-          'loading_icon', 'config_icon', 'error_icon')
-
-
 def test_variable_names_are_pushed_to_module_scope(expected_attrs):
   '''
   The dynamically initialized Globals() should contain the expected images at runtime
@@ -62,5 +56,3 @@ def make_user_files(*filenames):
 def cleanup_temp(*filenames):
   for filename in filenames:
     os.remove(os.path.join(tempfile.gettempdir(), filename))
-
-


### PR DESCRIPTION
I picked a couple of low-hanging fruit to increase test coverage.
I also found an apparently broken function and removed it, see cc2c095.
This also includes PR #128, as I wanted to start with all tests passing, I can rebase if you want.

I duplicated a fixture from argparse_to_json_unittest, see the TODO marker. This should probably go into a new conftest.py, so that tests can share one implementation. If that's alright with you I can add one.