### PR TITLE
Improve stop button

### DIFF
--- a/gooey/gui/util/taskkill.py
+++ b/gooey/gui/util/taskkill.py
@@ -3,10 +3,9 @@ import signal
 import psutil
 
 
-def _for_proc_and_children(proc, callback):
+def _for_all_children(proc, callback):
   for child in proc.children(recursive=True):
     callback(child)
-  callback(proc)
 
 
 def taskkill(pid, urgency=2):
@@ -17,8 +16,9 @@ def taskkill(pid, urgency=2):
   if os.name == 'nt':
     urgency = 3  # no urgency option available on Windows
   if urgency <= 1:
-    _for_proc_and_children(proc, lambda p: p.send_signal(signal.SIGINT))
+    _for_all_children(proc, lambda p: p.send_signal(signal.SIGINT))
   elif urgency == 2:
-    _for_proc_and_children(proc, lambda p: p.terminate())
+    _for_all_children(proc, lambda p: p.terminate())
   else:
-    _for_proc_and_children(proc, lambda p: p.kill())
+    _for_all_children(proc, lambda p: p.kill())
+    proc.kill()

--- a/gooey/gui/util/taskkill.py
+++ b/gooey/gui/util/taskkill.py
@@ -1,11 +1,8 @@
-import sys
-import os
-import signal
+import psutil
 
 
-if sys.platform.startswith("win"):
-  def taskkill(pid):
-    os.system('taskkill /F /PID {:d} /T >NUL 2>NUL'.format(pid))
-else:  # POSIX
-  def taskkill(pid):
-    os.kill(pid, signal.SIGTERM)
+def taskkill(pid):
+  proc = psutil.Process(pid)
+  for child in proc.children(recursive=True):
+    child.kill()
+  proc.kill()

--- a/gooey/gui/util/taskkill.py
+++ b/gooey/gui/util/taskkill.py
@@ -1,8 +1,24 @@
+import os
+import signal
 import psutil
 
 
-def taskkill(pid):
-  proc = psutil.Process(pid)
+def _for_proc_and_children(proc, callback):
   for child in proc.children(recursive=True):
-    child.kill()
-  proc.kill()
+    callback(child)
+  callback(proc)
+
+
+def taskkill(pid, urgency=2):
+  try:
+    proc = psutil.Process(pid)
+  except psutil.NoSuchProcess:
+    return
+  if os.name == 'nt':
+    urgency = 3  # no urgency option available on Windows
+  if urgency <= 1:
+    _for_proc_and_children(proc, lambda p: p.send_signal(signal.SIGINT))
+  elif urgency == 2:
+    _for_proc_and_children(proc, lambda p: p.terminate())
+  else:
+    _for_proc_and_children(proc, lambda p: p.kill())

--- a/gooey/languages/eng.py
+++ b/gooey/languages/eng.py
@@ -35,6 +35,7 @@ Uh oh! Looks like there was a problem.
 Copy the text from status window to let your developer know what went wrong.
 ''',
                'error_title': "Error",
+               'terminated': 'The task has been terminated by user.',
                'execution_finished': 'Execution finished',
                'success_message': 'Program completed sucessfully!',
 

--- a/gooey/languages/english.json
+++ b/gooey/languages/english.json
@@ -24,5 +24,6 @@
     "sure_you_want_to_exit": "Are you sure you want to exit?",
     "sure_you_want_to_stop": "Are you sure you want to stop the task? \nInterruption can corrupt your data!",
     "uh_oh": "\nUh oh! Looks like there was a problem. \nCopy the text from status window to let your developer know what went wrong.\n",
+    "terminated": "The task has been terminated by user.",
     "browse": "Browse"
 }


### PR DESCRIPTION
Suggesting improving stop button:
* no more blinking console window if program was frozen as win32gui app
* try to stop program gently on Linux and OSX: first pressing to stop button sends SIGINT to the program, second - SIGTERM, third and further - SIGKILL. Close button (cross) always sends SIGKILL. No any idea how to do this on Windows.

Example below shows the program that stops working only by third pressing of stop button (or immediately - on cross).
```python
#!/usr/bin/env python
# -*- coding: utf-8 -*-

from __future__ import unicode_literals
from __future__ import print_function

import sys
from time import sleep
from gooey import Gooey, GooeyParser


import signal
signal.signal(signal.SIGINT, lambda *_: None)  # ignore first attempt to stop
signal.signal(signal.SIGTERM, lambda *_: None)  # ignore second attempt to stop
# it is imposible to handle or ignore third attempt to stop - SIGKILL


@Gooey(progress_regex=r"^progress: (\d+)%$")
def main():
    parser = GooeyParser(prog="example_progress_bar_1")
    _ = parser.parse_args(sys.argv[1:])

    for i in range(100):
        print("progress: {}%".format(i+1))
        sys.stdout.flush()
        sleep(0.1)


if __name__ == "__main__":
    sys.exit(main())
```