### PR TITLE
Improve stop button 2

### DIFF
--- a/gooey/gui/model.py
+++ b/gooey/gui/model.py
@@ -111,6 +111,7 @@ class MyModel(object):
     self.auto_start = self.build_spec.get('auto_start')
     self.progress_regex = self.build_spec.get('progress_regex')
     self.progress_expr = self.build_spec.get('progress_expr')
+    self.progress_consume = self.build_spec.get('progress_consume')
     self.disable_progress_bar_animation = self.build_spec['disable_progress_bar_animation']
 
     self.program_name = self.build_spec.get('program_name')

--- a/gooey/gui/presenter.py
+++ b/gooey/gui/presenter.py
@@ -105,7 +105,8 @@ class Presenter(object):
     self.syncronize_from_model()
 
   def on_stop(self):
-    self.ask_stop()
+    if self.view.confirm_stop_dialog():
+      self.stop()
 
   def on_edit(self):
     self.model.update_state(States.CONFIGURING)
@@ -120,6 +121,12 @@ class Presenter(object):
       sys.exit()
 
   def on_close(self):
+    if self.model.stop_button_disabled:
+      return
+    if self.client_runner.running():
+      if not self.view.confirm_stop_dialog():
+        return
+      self.stop(force=True)
     self.view.Destroy()
     sys.exit()
 
@@ -138,14 +145,8 @@ class Presenter(object):
       self.model.update_state(States.ERROR)
     self.syncronize_from_model()
 
-  def ask_stop(self):
-    if self.view.confirm_stop_dialog():
-      self.stop()
-      return True
-    return False
-
-  def stop(self):
-    self.client_runner.stop()
+  def stop(self, force=False):
+    self.client_runner.stop(force)
 
   def configuring(self):
     self.view.hide_all_buttons()
@@ -180,5 +181,3 @@ class Presenter(object):
     # convenience method for syncronizing the model -> widget list collections
     for index, val in enumerate(new_values):
       collection[index].value = val
-
-

--- a/gooey/gui/presenter.py
+++ b/gooey/gui/presenter.py
@@ -14,7 +14,8 @@ class Presenter(object):
 
     self.client_runner = ProcessController(
       self.model.progress_regex,
-      self.model.progress_expr
+      self.model.progress_expr,
+      self.model.progress_consume,
     )
 
     pub.subscribe(self.on_cancel, events.WINDOW_CANCEL)

--- a/gooey/gui/processor.py
+++ b/gooey/gui/processor.py
@@ -67,7 +67,7 @@ class ProcessController(object):
       if progress is None or not self.progress_consume:
         pub.send_message('console_update', msg=line)
     if self._stop_urgency > 0:
-      pub.send_message('console_update', msg=_('terminated'))
+      pub.send_message('console_update', msg=_('terminated') + "\n")
     pub.send_message('execution_complete')
 
   def _extract_progress(self, text):

--- a/gooey/gui/processor.py
+++ b/gooey/gui/processor.py
@@ -6,36 +6,47 @@ from functools import partial
 from multiprocessing.dummy import Pool
 
 from gooey.gui.pubsub import pub
+from gooey.gui.lang.i18n import _
 from gooey.gui.util.casting import safe_float
 from gooey.gui.util.functional import unit, bind
-from gooey.gui.util.taskkill import taskkill
+from gooey.gui.util.taskkill import taskkill, MAX_URGENCY
 
 
 class ProcessController(object):
   def __init__(self, progress_regex, progress_expr):
     self._process = None
+    self._stop_urgency = 0
     self.progress_regex = progress_regex
     self.progress_expr = progress_expr
 
   def was_success(self):
     self._process.communicate()
-    return self._process.returncode == 0
+    return self._process.returncode == 0 and self._stop_urgency == 0
 
   def poll(self):
     if not self._process:
       raise Exception('Not started!')
     self._process.poll()
 
-  def stop(self):
-    if self.running():
-      taskkill(self._process.pid)
+  def stopping(self):
+    return self._stop_urgency > 0
+
+  def stop(self, force=False):
+    if not self.running():
+      return
+    if force:
+      self._stop_urgency = MAX_URGENCY
+    else:
+      self._stop_urgency += 1
+    taskkill(self._process.pid, self._stop_urgency)
 
   def running(self):
     return self._process and self.poll() is None
 
   def run(self, command):
+    self._stop_urgency = 0
     env = os.environ.copy()
-    env["GOOEY"] = "1"
+    env["GOOEY"] = str(os.getpid())
     self._process  = subprocess.Popen(command, bufsize=1, stdout=subprocess.PIPE,
                      stderr=subprocess.STDOUT, shell=True, env=env)
     Pool(1).apply_async(self._forward_stdout, (self._process,))
@@ -50,7 +61,11 @@ class ProcessController(object):
       if not line:
         break
       pub.send_message('console_update', msg=line)
-      pub.send_message('progress_update', progress=self._extract_progress(line))
+      progress = self._extract_progress(line)
+      if progress is not None:
+        pub.send_message('progress_update', progress=progress)
+    if self._stop_urgency > 0:
+      pub.send_message('console_update', msg=_('terminated'))
     pub.send_message('execution_complete')
 
   def _extract_progress(self, text):

--- a/gooey/gui/processor.py
+++ b/gooey/gui/processor.py
@@ -13,11 +13,12 @@ from gooey.gui.util.taskkill import taskkill, MAX_URGENCY
 
 
 class ProcessController(object):
-  def __init__(self, progress_regex, progress_expr):
+  def __init__(self, progress_regex, progress_expr, progress_consume):
     self._process = None
     self._stop_urgency = 0
     self.progress_regex = progress_regex
     self.progress_expr = progress_expr
+    self.progress_consume = progress_consume
 
   def was_success(self):
     self._process.communicate()
@@ -60,10 +61,11 @@ class ProcessController(object):
       line = process.stdout.readline()
       if not line:
         break
-      pub.send_message('console_update', msg=line)
       progress = self._extract_progress(line)
       if progress is not None:
         pub.send_message('progress_update', progress=progress)
+      if progress is None or not self.progress_consume:
+        pub.send_message('console_update', msg=line)
     if self._stop_urgency > 0:
       pub.send_message('console_update', msg=_('terminated'))
     pub.send_message('execution_complete')

--- a/gooey/gui/util/taskkill.py
+++ b/gooey/gui/util/taskkill.py
@@ -1,11 +1,27 @@
-import sys
 import os
 import signal
+import psutil
 
 
-if sys.platform.startswith("win"):
-  def taskkill(pid):
-    os.system('taskkill /F /PID {:d} /T >NUL 2>NUL'.format(pid))
-else:  # POSIX
-  def taskkill(pid):
-    os.kill(pid, signal.SIGTERM)
+MAX_URGENCY = 3
+
+
+def _for_all_children(proc, callback):
+  for child in proc.children(recursive=True):
+    callback(child)
+
+
+def taskkill(pid, urgency=2):
+  try:
+    proc = psutil.Process(pid)
+  except psutil.NoSuchProcess:
+    return
+  if os.name == 'nt':
+    urgency = MAX_URGENCY  # no urgency option available on Windows
+  if urgency <= 1:
+    _for_all_children(proc, lambda p: p.send_signal(signal.SIGINT))
+  elif urgency == 2:
+    _for_all_children(proc, lambda p: p.terminate())
+  else:
+    _for_all_children(proc, lambda p: p.kill())
+    proc.kill()

--- a/gooey/gui/windows/base_window.py
+++ b/gooey/gui/windows/base_window.py
@@ -195,7 +195,7 @@ class BaseWindow(wx.Frame):
       pb.Pulse()
     else:
       value = min(int(value), pb.GetRange())
-      if pb.GetValue() != value:
+      if pb.GetValue() != value or value == 0:
         # Windows 7 progress bar animation hack
         # http://stackoverflow.com/questions/5332616/disabling-net-progressbar-animation-when-changing-value
         if disable_animation and sys.platform.startswith("win"):
@@ -216,11 +216,11 @@ class BaseWindow(wx.Frame):
     self.show_dialog(_('error_title'), _('error_required_fields'), wx.ICON_ERROR)
 
   def confirm_exit_dialog(self):
-    result = self.show_dialog(_('sure_you_want_to_exit'), _('close_program'), wx.YES_NO)
+    result = self.show_dialog(_('close_program'), _('sure_you_want_to_exit'), wx.YES_NO)
     return result == YES
 
   def confirm_stop_dialog(self):
-    result = self.show_dialog(_('sure_you_want_to_stop'), _('stop_task'), wx.YES_NO)
+    result = self.show_dialog(_('stop_task'), _('sure_you_want_to_stop'), wx.YES_NO)
     return result == YES
 
 if __name__ == '__main__':

--- a/gooey/languages/eng.py
+++ b/gooey/languages/eng.py
@@ -35,6 +35,7 @@ Uh oh! Looks like there was a problem.
 Copy the text from status window to let your developer know what went wrong.
 ''',
                'error_title': "Error",
+               'terminated': 'The task has been terminated by user.',
                'execution_finished': 'Execution finished',
                'success_message': 'Program completed sucessfully!',
 

--- a/gooey/languages/english.json
+++ b/gooey/languages/english.json
@@ -24,5 +24,6 @@
     "sure_you_want_to_exit": "Are you sure you want to exit?",
     "sure_you_want_to_stop": "Are you sure you want to stop the task? \nInterruption can corrupt your data!",
     "uh_oh": "\nUh oh! Looks like there was a problem. \nCopy the text from status window to let your developer know what went wrong.\n",
+    "terminated": "The task has been terminated by user.",
     "browse": "Browse"
 }

--- a/gooey/python_bindings/config_generator.py
+++ b/gooey/python_bindings/config_generator.py
@@ -30,6 +30,7 @@ def create_from_parser(parser, source_path, **kwargs):
     'language_dir':         kwargs.get('language_dir'),
     'progress_regex':       kwargs.get('progress_regex'),
     'progress_expr':        kwargs.get('progress_expr'),
+    'progress_consume':     kwargs.get('progress_consume'),
     'disable_progress_bar_animation': kwargs.get('disable_progress_bar_animation'),
     'disable_stop_button':  kwargs.get('disable_stop_button'),
     'group_by_type':        kwargs.get('group_by_type', True)

--- a/gooey/python_bindings/gooey_decorator.py
+++ b/gooey/python_bindings/gooey_decorator.py
@@ -33,6 +33,7 @@ def Gooey(f=None,
           language_dir=get_resource_path('languages'),
           progress_regex=None, # TODO: add this to the docs
           progress_expr=None, # TODO: add this to the docs
+          progress_consume=False, # TODO: add this to the docs
           disable_progress_bar_animation=False,
           disable_stop_button=False,
           group_by_type=True): # TODO: add this to the docs

--- a/gooey/python_bindings/gooeyed.py
+++ b/gooey/python_bindings/gooeyed.py
@@ -1,0 +1,18 @@
+import os
+import psutil
+
+
+def gooeyed():
+  gooey_env_value = os.environ.get("GOOEY")
+  if not gooey_env_value:
+    return False
+  try:
+    gooey_pid = int(gooey_env_value)
+  except ValueError:
+    return False
+  proc = psutil.Process()
+  while proc:
+    if proc.pid == gooey_pid:
+      return True
+    proc = proc.parent()
+  return False


### PR DESCRIPTION
Finally, I managed to port changes from PR #138 and some useful ideas from #139.

Improve stop button:
* no more blinking console window if program was frozen with cx_Freeze as win32gui application.
* try to stop program gently on Linux and OSX: first pressing to stop button sends SIGINT to the program, second - SIGTERM, third and further - SIGKILL. Close button (cross) always sends SIGKILL. No any idea how to do this on Windows.

Example below shows the program that stops working only by third pressing of stop button (or immediately - on cross).
```python
#!/usr/bin/env python
# -*- coding: utf-8 -*-

from __future__ import unicode_literals
from __future__ import print_function

import sys
from time import sleep
from gooey import Gooey, GooeyParser


import signal
signal.signal(signal.SIGINT, lambda *_: None)  # ignore first attempt to stop
signal.signal(signal.SIGTERM, lambda *_: None)  # ignore second attempt to stop
# it is imposible to handle or ignore third attempt to stop - SIGKILL


@Gooey(progress_regex=r"^progress: (\d+)%$")
def main():
    parser = GooeyParser(prog="example_progress_bar_1")
    _ = parser.parse_args(sys.argv[1:])

    for i in range(100):
        print("progress: {}%".format(i+1))
        sys.stdout.flush()
        sleep(0.1)


if __name__ == "__main__":
    sys.exit(main())
```

Other changes:
* add new option `progress_consume` - gooey does not print line if it is recognised as progress. No more spamming in the status window!
* add `gooey.python_bindings.gooeyed` module with one function `gooeyed`. It returns True if program is run inside Gooey.