### PR TITLE
Fix subprocess to work properly when frozen

### DIFF
--- a/gooey/gui/processor.py
+++ b/gooey/gui/processor.py
@@ -40,7 +40,7 @@ class ProcessController(object):
     env["GOOEY"] = "1"
     self._process = subprocess.Popen(
       command.encode(sys.getfilesystemencoding()),
-      bufsize=1, stdout=subprocess.PIPE,
+      bufsize=1, stdout=subprocess.PIPE, stdin=subprocess.PIPE,
       stderr=subprocess.STDOUT, shell=True, env=env)
     Pool(1).apply_async(self._forward_stdout, (self._process,))
 


### PR DESCRIPTION
This fixes frozen Gooey scripts when frozen using PyInstaller. #58 
See: http://stackoverflow.com/a/10338737/74123
