### PR TITLE
Add 'parse_only' option to receive arguments from GUI and return to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Just about everything in Gooey can be customized by passing arguments to the dec
 | advanced | Toggles whether to show the 'full' configuration screen, or a simplified version | 
 | show_config | Skips the configuration all together and runs the program immediately |
 | language | Tells Gooey which language set to load from the `gooey/languages` directory.|
-|program_name | The name displayed in the title bar of the GUI window. If not supplied, the title defaults to the script name pulled from `sys.argv[0]`. |
+| program_name | The name displayed in the title bar of the GUI window. If not supplied, the title defaults to the script name pulled from `sys.argv[0]`. |
 | program_description | Sets the text displayed in the top panel of the `Settings` screen. Defaults to the description pulled from `ArgumentParser`. |
 | default_size | Initial size of the window | 
 | required_cols | Controls how many columns are in the Required Arguments section |
@@ -257,7 +257,7 @@ Just about everything in Gooey can be customized by passing arguments to the dec
 | monospace_display | Uses a mono-spaced font in the output screen | 
 | image_dir | Path to the directory in which Gooey should look for custom images/icons |
 | language_dir | Path to the directory in which Gooey should look for custom languages files |
-
+| parse_only | Receive arguments from GUI and return to previous environment(mostly CLI) with arguments. Should be a tuple of (argumentParser, callback_function(parsed_arguments)) |
 
 
 Run Modes

--- a/gooey/gui/model.py
+++ b/gooey/gui/model.py
@@ -206,11 +206,17 @@ class MyModel(object):
   def skipping_config(self):
     return self.build_spec['manual_start']
 
+  def parse_only_parser(self):
+    return self.build_spec['parse_only_parser']
+
+  def parse_only_callback(self):
+    return self.build_spec['parse_only_callback']
+
   def is_required_section_complete(self):
     completed_values = filter(None, [arg.value for arg in self.required_args])
     return len(self.required_args) == len(completed_values)
 
-  def build_command_line_string(self):
+  def build_command_line_options_string(self):
     optional_args = [arg.value for arg in self.optional_args]
     required_args = [c.value for c in self.required_args if c.commands]
     position_args = [c.value for c in self.required_args if not c.commands]
@@ -219,6 +225,10 @@ class MyModel(object):
     cmd_string = ' '.join(filter(None, chain(required_args, optional_args, position_args)))
     if self.layout_type == 'column':
       cmd_string = u'{} {}'.format(self.argument_groups[self.active_group].command, cmd_string)
+    return cmd_string
+
+  def build_command_line_string(self):
+    cmd_string = self.build_command_line_options_string()
     return u'{} --ignore-gooey {}'.format(self.build_spec['target'], cmd_string)
 
   def group_arguments(self, widget_list):

--- a/gooey/python_bindings/config_generator.py
+++ b/gooey/python_bindings/config_generator.py
@@ -13,6 +13,8 @@ def create_from_parser(parser, source_path, **kwargs):
   else:
     run_cmd = '{} -u {}'.format(quote(sys.executable), quote(source_path))
 
+  parse_only = kwargs.get('parse_only', None)
+  
   build_spec = {
     'language':             kwargs.get('language', 'english'),
     'target':               run_cmd,
@@ -32,7 +34,9 @@ def create_from_parser(parser, source_path, **kwargs):
     'progress_expr':        kwargs.get('progress_expr'),
     'disable_progress_bar_animation': kwargs.get('disable_progress_bar_animation'),
     'disable_stop_button':  kwargs.get('disable_stop_button'),
-    'group_by_type':        kwargs.get('group_by_type', True)
+    'group_by_type':        kwargs.get('group_by_type', True),
+    'parse_only_parser':    parse_only[0] if parse_only else None,
+    'parse_only_callback':  parse_only[1] if parse_only else None
   }
 
   if not auto_start:

--- a/gooey/python_bindings/gooey_decorator.py
+++ b/gooey/python_bindings/gooey_decorator.py
@@ -35,7 +35,8 @@ def Gooey(f=None,
           progress_expr=None, # TODO: add this to the docs
           disable_progress_bar_animation=False,
           disable_stop_button=False,
-          group_by_type=True): # TODO: add this to the docs
+          group_by_type=True, # TODO: add this to the docs
+          parse_only=None):
   '''
   Decorator for client code's main function.
   Serializes argparse data to JSON for use with the Gooey front end


### PR DESCRIPTION
Some terminal-specific api calls(ex, curse.cbreak()) yields error and can't be adopted to current Gooey(wxPython) environment.
Receiving arguments from GUI and returning them to original process(mostly CLI) may resolve this issue, by supplying "Settings" window only and calling callback function when "Start" button is clicked.

I couldn't come up with any better name for the option "parse_only", though it may not be intuitive.