### PR TITLE
wxpython 4.0.0a1 and Python 3

### DIFF
--- a/gooey/gui/imageutil.py
+++ b/gooey/gui/imageutil.py
@@ -19,13 +19,13 @@ def resize_bitmap(parent, _bitmap, target_height):
   size of the top panel), while keeping aspect ratio
   in tact
   '''
-  image = wx.ImageFromBitmap(_bitmap)
+  image = _bitmap.ConvertToImage()
   _width, _height = image.GetSize()
   if _height < target_height:
-    return wx.StaticBitmap(parent, -1, wx.BitmapFromImage(image))
+    return wx.StaticBitmap(parent, -1, wx.Bitmap(image))
   ratio = float(_width) / _height
   image = image.Scale(target_height * ratio, target_height, wx.IMAGE_QUALITY_HIGH)
-  return wx.StaticBitmap(parent, -1, wx.BitmapFromImage(image))
+  return wx.StaticBitmap(parent, -1, wx.Bitmap(image))
 
 
 

--- a/gooey/gui/lang/i18n.py
+++ b/gooey/gui/lang/i18n.py
@@ -7,6 +7,7 @@ Provides Internationalization for all text within the program.
 
 '''
 
+import io
 import os
 import json
 
@@ -19,7 +20,7 @@ def load(language_dir, filename):
   global _DICTIONARY
   try:
     json_file = filename + '.json'
-    with open(os.path.join(language_dir, json_file), 'rb') as f:
+    with io.open(os.path.join(language_dir, json_file), 'r', encoding='utf-8') as f:
       _DICTIONARY = json.load(f)
   except IOError:
     raise IOError('{0} Language file not found at location {1}. '

--- a/gooey/gui/model.py
+++ b/gooey/gui/model.py
@@ -158,7 +158,7 @@ class MyModel(object):
     self.stop_button_disabled = self.build_spec['disable_stop_button']
 
     self.argument_groups = self.wrap(self.build_spec.get('widgets', {}))
-    self.active_group = iter(self.argument_groups).next()
+    self.active_group = next(iter(self.argument_groups))
 
     self.num_required_cols = self.build_spec['num_required_cols']
     self.num_optional_cols = self.build_spec['num_optional_cols']
@@ -207,7 +207,7 @@ class MyModel(object):
     return self.build_spec['manual_start']
 
   def is_required_section_complete(self):
-    completed_values = filter(None, [arg.value for arg in self.required_args])
+    completed_values = list(filter(None, [arg.value for arg in self.required_args]))
     return len(self.required_args) == len(completed_values)
 
   def build_command_line_string(self):
@@ -216,7 +216,7 @@ class MyModel(object):
     position_args = [c.value for c in self.required_args if not c.commands]
     if position_args:
       position_args.insert(0, "--")
-    cmd_string = ' '.join(filter(None, chain(required_args, optional_args, position_args)))
+    cmd_string = ' '.join(list(filter(None, chain(required_args, optional_args, position_args))))
     if self.layout_type == 'column':
       cmd_string = u'{} {}'.format(self.argument_groups[self.active_group].command, cmd_string)
     return u'{} --ignore-gooey {}'.format(self.build_spec['target'], cmd_string)
@@ -228,11 +228,11 @@ class MyModel(object):
     required_args, optional_args  = self.partition(widget_list, is_required)
     if self.build_spec['group_by_type']:
       optional_args = chain(*self.partition(optional_args, not_checkbox))
-    return map(self.to_object, required_args), map(self.to_object, optional_args)
+    return list(map(self.to_object, required_args)), list(map(self.to_object, optional_args))
 
   @staticmethod
   def partition(collection, condition):
-    return filter(condition, collection), filter(lambda x: not condition(x), collection)
+    return list(filter(condition, collection)), list(filter(lambda x: not condition(x), collection))
 
   def to_object(self, data):
     details = data['data']

--- a/gooey/gui/presenter.py
+++ b/gooey/gui/presenter.py
@@ -58,7 +58,7 @@ class Presenter(object):
       self.view.enable_stop_button()
 
     if self.model.layout_type == layouts.COLUMN:
-      self.view.set_list_contents(self.model.argument_groups.keys())
+      self.view.set_list_contents(list(self.model.argument_groups.keys()))
 
     if self.model.auto_start:
       self.model.update_state(States.RUNNNING)

--- a/gooey/gui/processor.py
+++ b/gooey/gui/processor.py
@@ -38,10 +38,16 @@ class ProcessController(object):
   def run(self, command):
     env = os.environ.copy()
     env["GOOEY"] = "1"
-    self._process = subprocess.Popen(
-      command.encode(sys.getfilesystemencoding()),
-      bufsize=1, stdout=subprocess.PIPE,
-      stderr=subprocess.STDOUT, shell=True, env=env)
+    try:
+      self._process = subprocess.Popen(
+        command.encode(sys.getfilesystemencoding()),
+        bufsize=1, stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT, shell=True, env=env)
+    except:
+      self._process = subprocess.Popen(
+        command,
+        bufsize=1, stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT, shell=True, env=env)
     Pool(1).apply_async(self._forward_stdout, (self._process,))
 
   def _forward_stdout(self, process):

--- a/gooey/gui/util/wx_util.py
+++ b/gooey/gui/util/wx_util.py
@@ -8,7 +8,7 @@ import wx
 def make_bold(statictext):
   pointsize = statictext.GetFont().GetPointSize()
   font = wx.Font(pointsize, wx.FONTFAMILY_DEFAULT,
-                 wx.FONTWEIGHT_NORMAL, wx.FONTWEIGHT_BOLD, False)
+                 wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD, False)
   statictext.SetFont(font)
 
 def dark_grey(statictext):
@@ -18,15 +18,15 @@ def dark_grey(statictext):
 def h0(parent, label):
   text = wx.StaticText(parent, label=label)
   font_size = text.GetFont().GetPointSize()
-  font = wx.Font(font_size * 1.4, *(wx.FONTFAMILY_DEFAULT, wx.FONTWEIGHT_NORMAL, wx.FONTWEIGHT_BOLD, False))
+  font = wx.Font(font_size * 1.4, *(wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD, False))
   text.SetFont(font)
   return text
 
 def h1(parent, label):
-  return _header(parent, label, (wx.FONTFAMILY_DEFAULT, wx.FONTWEIGHT_NORMAL, wx.FONTWEIGHT_BOLD, False))
+  return _header(parent, label, (wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD, False))
 
 def h2(parent, label):
-  return _header(parent, label, (wx.FONTFAMILY_DEFAULT, wx.FONTWEIGHT_NORMAL, wx.FONTWEIGHT_NORMAL, False))
+  return _header(parent, label, (wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL, False))
 
 def _header(parent, label, styles):
   text = wx.StaticText(parent, label=label)

--- a/gooey/gui/widgets/calender_dialog.py
+++ b/gooey/gui/widgets/calender_dialog.py
@@ -1,6 +1,7 @@
 __author__ = 'Chris'
 
 import wx
+import wx.adv
 
 from gooey.gui.util import wx_util
 
@@ -12,7 +13,7 @@ class CalendarDlg(wx.Dialog):
     self.SetBackgroundColour('#ffffff')
 
     self.ok_button = wx.Button(self, wx.ID_OK, label='Ok')
-    self.datepicker = wx.DatePickerCtrl(self, style=wx.DP_DROPDOWN)
+    self.datepicker = wx.adv.DatePickerCtrl(self, style=wx.adv.DP_DROPDOWN)
 
     vertical_container = wx.BoxSizer(wx.VERTICAL)
     vertical_container.AddSpacer(10)

--- a/gooey/gui/widgets/components.py
+++ b/gooey/gui/widgets/components.py
@@ -54,7 +54,7 @@ class BaseGuiComponent(object):
     return self.panel
 
   def bind(self, *args, **kwargs):
-    print self.widget_pack.widget.Bind(*args, **kwargs)
+    print(self.widget_pack.widget.Bind(*args, **kwargs))
 
   def get_title(self):
     return self.title.GetLabel()
@@ -104,7 +104,7 @@ class BaseGuiComponent(object):
 
   def set_value(self, val):
     if val:
-      self.widget_pack.widget.SetValue(unicode(val))
+      self.widget_pack.widget.SetValue(str(val))
 
   def __repr__(self):
     return self.__class__.__name__
@@ -196,9 +196,9 @@ class RadioGroup(object):
     return self.panel
 
   def showz(self, evt):
-    print evt
+    print(evt)
     for i in self.radio_buttons:
-      print i.GetValue()
+      print(i.GetValue())
 
   def onResize(self, evt):
     msg = self.help_msgs[0]

--- a/gooey/gui/widgets/widget_pack.py
+++ b/gooey/gui/widgets/widget_pack.py
@@ -184,7 +184,7 @@ class CounterPayload(WidgetPack):
       parent=parent,
       id=-1,
       value='',
-      choices=map(str, range(1, 11)),
+      choices=list(map(str, range(1, 11))),
       style=wx.CB_DROPDOWN
     )
     return self.widget

--- a/gooey/gui/windows/advanced_config.py
+++ b/gooey/gui/windows/advanced_config.py
@@ -7,7 +7,10 @@ Managed the internal layout for configuration options
 
 import wx
 from wx.lib.scrolledpanel import ScrolledPanel
-from itertools import chain, izip_longest
+try:
+    from itertools import zip_longest
+except ImportError:
+    from itertools import izip_longest as zip_longest
 
 from gooey.gui.util import wx_util
 from gooey.gui.lang import i18n
@@ -69,7 +72,7 @@ class WidgetContainer(wx.Panel):
   def chunk(self, iterable, n, fillvalue=None):
     "itertools recipe: Collect data into fixed-length chunks or blocks"
     args = [iter(iterable)] * n
-    return izip_longest(fillvalue=fillvalue, *args)
+    return zip_longest(fillvalue=fillvalue, *args)
 
   def __iter__(self):
     return iter(self.widgets)

--- a/gooey/gui/windows/base_window.py
+++ b/gooey/gui/windows/base_window.py
@@ -191,6 +191,8 @@ class BaseWindow(wx.Frame):
 
   def UpdateProgressBar(self, value, disable_animation=False):
     pb = self.foot_panel.progress_bar
+    if value is None:
+      return
     if value < 0:
       pb.Pulse()
     else:

--- a/gooey/gui/windows/footer.py
+++ b/gooey/gui/windows/footer.py
@@ -5,7 +5,6 @@ Created on Dec 23, 2013
 '''
 
 import wx
-import wx.animate
 
 from gooey.gui.pubsub import pub
 

--- a/gooey/gui/windows/runtime_display_panel.py
+++ b/gooey/gui/windows/runtime_display_panel.py
@@ -22,7 +22,7 @@ class RuntimeDisplay(wx.Panel):
   def set_font_style(self, style):
     pointsize = self.cmd_textbox.GetFont().GetPointSize()
     font = wx.Font(pointsize, style,
-                 wx.FONTWEIGHT_NORMAL, wx.FONTWEIGHT_BOLD, False)
+                 wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD, False)
     self.cmd_textbox.SetFont(font)
 
   def _init_properties(self):

--- a/gooey/python_bindings/argparse_to_json.py
+++ b/gooey/python_bindings/argparse_to_json.py
@@ -63,7 +63,7 @@ def convert(parser):
       (choose_name(name, sub_parser), {
         'command': name.lower(),
         'contents': process(sub_parser, getattr(sub_parser, 'widgets', {}))
-      }) for name, sub_parser in get_subparser(actions).choices.iteritems())
+      }) for name, sub_parser in get_subparser(actions).choices.items())
 
   else:
     layout_type = 'standard'
@@ -96,7 +96,7 @@ def process(parser, widget_dict):
 
   return list(categorize(required_actions, widget_dict, required=True)) + \
          list(categorize(optional_actions, widget_dict)) + \
-         map(build_radio_group, mutually_exclusive_groups)
+         list(map(build_radio_group, mutually_exclusive_groups))
 
 def categorize(actions, widget_dict, required=False):
   _get_widget = partial(get_widget, widgets=widget_dict)
@@ -110,7 +110,7 @@ def categorize(actions, widget_dict, required=False):
     elif is_counter(action):
       _json = as_json(action, _get_widget(action) or 'Counter', required)
       # pre-fill the 'counter' dropdown
-      _json['data']['choices'] = map(str, range(1, 11))
+      _json['data']['choices'] = list(map(str, range(1, 11)))
       yield _json
     else:
       raise UnknownWidgetType(action)
@@ -125,16 +125,16 @@ def is_required(action):
   return not action.option_strings and not isinstance(action, _SubParsersAction) or action.required == True
 
 def has_required(actions):
-  return filter(None, filter(is_required, actions))
+  return list(filter(None, list(filter(is_required, actions))))
 
 def is_subparser(action):
   return isinstance(action,_SubParsersAction)
 
 def has_subparsers(actions):
-    return filter(is_subparser, actions)
+    return list(filter(is_subparser, actions))
 
 def get_subparser(actions):
-    return filter(is_subparser, actions)[0]
+    return list(filter(is_subparser, actions))[0]
 
 def is_optional(action):
   '''_actions not positional or possessing the `required` flag'''
@@ -161,7 +161,7 @@ def is_standard(action):
 def is_flag(action):
   """ _actions which are either storeconst, store_bool, etc.. """
   action_types = [_StoreTrueAction, _StoreFalseAction, _StoreConstAction]
-  return any(map(lambda Action: isinstance(action, Action), action_types))
+  return any(list(map(lambda Action: isinstance(action, Action), action_types)))
 
 def is_counter(action):
   """ _actions which are of type _CountAction """

--- a/gooey/python_bindings/gooey_decorator.py
+++ b/gooey/python_bindings/gooey_decorator.py
@@ -51,7 +51,7 @@ def Gooey(f=None,
       if load_build_config:
         try:
           build_spec = json.load(open(load_build_config, "r"))
-        except Exception, e:
+        except Exception as e:
           print( 'Exception loading Build Config from {0}: {1}'.format(load_build_config, e))
           sys.exit(1)
 
@@ -60,7 +60,7 @@ def Gooey(f=None,
 
       if dump_build_config:
         config_path = os.path.join(os.getcwd(), 'gooey_config.json')
-        print 'Writing Build Config to: {}'.format(config_path)
+        print('Writing Build Config to: {}'.format(config_path))
         with open(config_path, 'w') as f:
           f.write(json.dumps(build_spec, indent=2))
       application.run(build_spec)

--- a/gooey/tests/test_argparse_to_json.py
+++ b/gooey/tests/test_argparse_to_json.py
@@ -27,7 +27,7 @@ def test_grouping_structure(complete_parser):
   # should now be a dict rather than a list
   assert isinstance(groupings, dict)
   # make sure our expected root keys are there
-  for name, group in groupings.iteritems():
+  for name, group in groupings.items():
     assert 'command' in group
     assert 'contents' in group
     # contents should be the old list of widget info
@@ -60,7 +60,7 @@ def test_convert_std_parser(complete_parser):
   result = convert(complete_parser)
   # grab the first entry from the dict
   entry = result['widgets']['primary']['contents'][0]
-  print entry
+  print(entry)
   assert 'type' in entry
   assert 'required' in entry
   assert 'data' in entry
@@ -85,14 +85,14 @@ def test_has_subparsers(subparser, complete_parser):
 
 
 def test_is_required(complete_parser):
-  required = filter(is_required, complete_parser._actions)
+  required = list(filter(is_required, complete_parser._actions))
   assert len(required) == 4
   for action in required:
-    print action.dest.startswith('req')
+    print(action.dest.startswith('req'))
 
 
 def test_is_optional(complete_parser):
-  optional = filter(is_optional, complete_parser._actions)
+  optional = list(filter(is_optional, complete_parser._actions))
   assert len(optional) == 10
   for action in optional:
     assert 'req' not in action.dest


### PR DESCRIPTION
I have updated Gooey to wxpython 4.0.0.a1 and Python 3. Wxpython 4.0.0.a1 is just in an alpha release. The changes are not compatible to wxpython 3 anymore, but they are still compatible to Python 2.

I have tested it with Python 2.7 and 3.5

All examples from https://github.com/chriskiehl/GooeyExamples and the unittests run fine (except for the presentation tests).

@chriskiehl I know it is planned to change the backend to PyQt5. So I understand if this PR is not merged, but nevertheless these changes might be useful for everyone who has to update their software to Python 3.
 
Relevant issue: https://github.com/chriskiehl/Gooey/issues/65