### PR TITLE
Adding ability to override executable target

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Different styling and functionality can be configured by passing arguments into 
     @Gooey(advanced=Boolean,          # toggle whether to show advanced config or not 
            language=language_string,  # Translations configurable via json
            show_config=True,          # skip config screens all together
+           target=executable_cmd,     # Explicitly set the subprocess executable arguments
            program_name='name',       # Defaults to script name
            program_description,       # Defaults to ArgParse Description
            default_size=(610, 530),   # starting size of the GUI
@@ -247,6 +248,7 @@ Just about everything in Gooey can be customized by passing arguments to the dec
 | advanced | Toggles whether to show the 'full' configuration screen, or a simplified version | 
 | show_config | Skips the configuration all together and runs the program immediately |
 | language | Tells Gooey which language set to load from the `gooey/languages` directory.|
+| target | Tells Gooey how to re-invoke itself. By default Gooey will find python, but this allows you to specify the program (and arguments if supplied).|
 |program_name | The name displayed in the title bar of the GUI window. If not supplied, the title defaults to the script name pulled from `sys.argv[0]`. |
 | program_description | Sets the text displayed in the top panel of the `Settings` screen. Defaults to the description pulled from `ArgumentParser`. |
 | default_size | Initial size of the window | 

--- a/gooey/python_bindings/config_generator.py
+++ b/gooey/python_bindings/config_generator.py
@@ -8,10 +8,12 @@ from gooey.gui.util.quoting import quote
 def create_from_parser(parser, source_path, **kwargs):
   auto_start = kwargs.get('auto_start', False)
 
-  if hasattr(sys, 'frozen'):
-    run_cmd = quote(source_path)
-  else:
-    run_cmd = '{} -u {}'.format(quote(sys.executable), quote(source_path))
+  run_cmd = kwargs.get('target')
+  if run_cmd is None:
+    if hasattr(sys, 'frozen'):
+      run_cmd = quote(source_path)
+    else:
+      run_cmd = '{} -u {}'.format(quote(sys.executable), quote(source_path))
 
   build_spec = {
     'language':             kwargs.get('language', 'english'),

--- a/gooey/python_bindings/gooey_decorator.py
+++ b/gooey/python_bindings/gooey_decorator.py
@@ -21,6 +21,7 @@ def Gooey(f=None,
           advanced=True,
           language='english',
           auto_start=False,  # TODO: add this to the docs. Used to be `show_config=True`
+          target=None,
           program_name=None,
           program_description=None,
           default_size=(610, 530),


### PR DESCRIPTION
We use a custom executable to configure our python environment, but the logic for determining the target assumes we are using the sys.program or are frozen.

Adding the ability to specify a target override.