### PR TITLE
Features to allow easier use of command line with Gooey

### DIFF
--- a/gooey/gui/model.py
+++ b/gooey/gui/model.py
@@ -219,7 +219,7 @@ class MyModel(object):
     cmd_string = ' '.join(list(filter(None, chain(required_args, optional_args, position_args))))
     if self.layout_type == 'column':
       cmd_string = u'{} {}'.format(self.argument_groups[self.active_group].command, cmd_string)
-    return u'{} --ignore-gooey {}'.format(self.build_spec['target'], cmd_string)
+    return u'{} {} {}'.format(self.build_spec['target'], self.build_spec['ignore_command'] or '', cmd_string)
 
   def group_arguments(self, widget_list):
     is_required = lambda widget: widget['required']

--- a/gooey/python_bindings/config_generator.py
+++ b/gooey/python_bindings/config_generator.py
@@ -5,7 +5,7 @@ from gooey.python_bindings import argparse_to_json
 from gooey.gui.util.quoting import quote
 
 
-def create_from_parser(parser, source_path, **kwargs):
+def create_from_parser(parser, source_path, cmd_args, **kwargs):
   auto_start = kwargs.get('auto_start', False)
 
   run_cmd = kwargs.get('target')
@@ -34,13 +34,15 @@ def create_from_parser(parser, source_path, **kwargs):
     'progress_expr':        kwargs.get('progress_expr'),
     'disable_progress_bar_animation': kwargs.get('disable_progress_bar_animation'),
     'disable_stop_button':  kwargs.get('disable_stop_button'),
-    'group_by_type':        kwargs.get('group_by_type', True)
+    'group_by_type':        kwargs.get('group_by_type', True),
+    'ignore_command':       kwargs.get('ignore_command', None),
+    'force_command':        kwargs.get('force_command', None)
   }
 
   if not auto_start:
     build_spec['program_description'] = parser.description or build_spec['program_description']
 
-    layout_data = argparse_to_json.convert(parser) if build_spec['show_advanced'] else layouts.basic_config.items()
+    layout_data = argparse_to_json.convert(parser, cmd_args=cmd_args) if build_spec['show_advanced'] else layouts.basic_config.items()
     build_spec.update(layout_data)
 
   return build_spec

--- a/gooey/python_bindings/gooey_decorator.py
+++ b/gooey/python_bindings/gooey_decorator.py
@@ -15,8 +15,6 @@ from gooey.gui import application
 from gooey.gui.util.freeze import get_resource_path
 from . import config_generator
 
-IGNORE_COMMAND = '--ignore-gooey'
-
 def Gooey(f=None,
           advanced=True,
           language='english',
@@ -36,7 +34,10 @@ def Gooey(f=None,
           progress_expr=None, # TODO: add this to the docs
           disable_progress_bar_animation=False,
           disable_stop_button=False,
-          group_by_type=True): # TODO: add this to the docs
+          group_by_type=True, # TODO: add this to the docs
+          ignore_command='--ignore-gooey',
+          force_command=None,
+          load_cmd_args=False):
   '''
   Decorator for client code's main function.
   Serializes argparse data to JSON for use with the Gooey front end
@@ -57,7 +58,14 @@ def Gooey(f=None,
           sys.exit(1)
 
       if not build_spec:
-        build_spec = config_generator.create_from_parser(self, source_path, payload_name=payload.__name__, **params)
+        cmd_args = None
+        if load_cmd_args:
+          try:
+            cmd_args = self.original_parse_args()
+          except:
+            pass
+
+        build_spec = config_generator.create_from_parser(self, source_path, cmd_args, payload_name=payload.__name__, **params)
 
       if dump_build_config:
         config_path = os.path.join(os.getcwd(), 'gooey_config.json')
@@ -75,17 +83,31 @@ def Gooey(f=None,
     return inner2
 
   def run_without_gooey(func):
-    return lambda: func()
+    def inner2(*args, **kwargs):
+      return func(*args, **kwargs)
 
-  if IGNORE_COMMAND in sys.argv:
-    sys.argv.remove(IGNORE_COMMAND)
+    inner2.__name__ = func.__name__
+    return inner2
+
+  gooey = True
+  if ignore_command and ignore_command in sys.argv:
+    sys.argv.remove(ignore_command)
+    gooey = False
+
+  if force_command:
+    if force_command in sys.argv:
+      sys.argv.remove(force_command)
+    else:
+      gooey = False
+
+  if gooey:
+    if callable(f):
+        return build(f)
+    return build
+  else:
     if callable(f):
       return run_without_gooey(f)
     return run_without_gooey
-
-  if callable(f):
-    return build(f)
-  return build
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This pull request incorporates three related changes.

1. The simplest is really a bug fix. Previously if you used the `@Gooey` decorator on a function with one or more arguments and called the parser with `--ignore-gooey`, Python failed with

> TypeError: <lambda>() takes no arguments (1 given)

This was fixed by modifying the `run_without_gooey` function to used an `inner2` function like `run_gooey` does.

2. The second modification allows the IGNORE_COMMAND argument to be specified as an argument (`ignore_command`)  to the `@Gooey` decorator (I did this because prefer `--no-gui` to  `--ignore-gooey`) and adds a further argument (`force_command`) to be specified. The latter argument reverses the default functionality, so that the script is run without Gooey unless the argument is specified. For example:

> my_command --gui

3. A slightly more complicated change responds to #200 by adding a boolean argument `load_cmd_args` to the `@Gooey` decorator.  If this argument is specified then Gooey will parse the arguments from the command line invocation, and use the resulting values as default values (over-riding defaults specified in the Python script) when the GUI is generated. Note that this functionality could be improved by allowing positional arguments to be skipped and not enforcing `required` when parsing the command line arguments.