### PR TITLE
Don't convert subparser name to lower case

### DIFF
--- a/gooey/python_bindings/argparse_to_json.py
+++ b/gooey/python_bindings/argparse_to_json.py
@@ -61,7 +61,7 @@ def convert(parser):
     layout_type = 'column'
     layout_data = OrderedDict(
       (choose_name(name, sub_parser), {
-        'command': name.lower(),
+        'command': name,
         'contents': process(sub_parser, getattr(sub_parser, 'widgets', {}))
       }) for name, sub_parser in get_subparser(actions).choices.iteritems())
 


### PR DESCRIPTION
Gooey currently fails when a subparser has a name that is not in lower case:

> usage: testgui.py [-h] {lowerUPPER} ...
> testgui.py: error: invalid choice: 'lowerupper (choose from 'lowerUPPER')

This patch removes the conversion of subparser names to lower case, which resolves the problem.