### PR TITLE
Groups

### DIFF
--- a/gooey/gui/controller.py
+++ b/gooey/gui/controller.py
@@ -7,7 +7,7 @@ class Controller(object):
 
   def __init__(self, build_spec):
     self.model = MyModel(build_spec)
-    self.view = BaseWindow(layout_type=self.model.layout_type)
+    self.view = BaseWindow(layout_type=self.model.layout_type, use_tabs=self.model.use_tabs)
     self.presentation = Presenter(self.view, self.model)
     self.presentation.initialize_view()
 

--- a/gooey/gui/model.py
+++ b/gooey/gui/model.py
@@ -6,14 +6,14 @@ from gooey.gui.util.quoting import quote
 
 import wx
 
-ArgumentGroup = namedtuple('ArgumentGroup', 'name command required_args optional_args')
+ArgumentGroup = namedtuple('ArgumentGroup', 'name command arguments_dict')
 
 
 class MyWidget(object):
   # TODO: Undumbify damn
   # TODO: Undumbify _value/value access
 
-  def __init__(self, type, title, help, default, nargs, commands, choices):
+  def __init__(self, type, title, help, default, nargs, commands, choices, required):
     self.type = type
     self.title = title
     self.help = help
@@ -22,6 +22,7 @@ class MyWidget(object):
     self.nargs = nargs
     self.commands = commands
     self.choices = choices
+    self.required = required
 
   @property
   def value(self):
@@ -133,13 +134,20 @@ class MyModel(object):
   def wrap(self, groups):
     output = OrderedDict()
     for name, group in groups.items():
-      output[name] = ArgumentGroup(
-        name,
-        group['command'],
-        *self.group_arguments(group['contents'])
-      )
+      if self.use_argparse_groups:
+        output[name] = ArgumentGroup(
+          name,
+          group['command'],
+          OrderedDict([(group_name, map(self.to_object, group['contents'][group_name])) for group_name in group['contents']])
+        )
+      else:
+        required_arguments, optional_arguments = self.group_arguments(group['contents'])
+        output[name] = ArgumentGroup(
+          name,
+          group['command'],
+          OrderedDict([("required arguments", required_arguments), ("optional arguments", optional_arguments)])
+        )
     return output
-
 
   def __init__(self, build_spec):
 
@@ -162,11 +170,14 @@ class MyModel(object):
     self.use_monospace_font = self.build_spec.get('monospace_display')
     self.stop_button_disabled = self.build_spec['disable_stop_button']
 
+    self.use_argparse_groups = self.build_spec['use_argparse_groups']
     self.argument_groups = self.wrap(self.build_spec.get('widgets', {}))
     self.active_group = next(iter(self.argument_groups))
 
-    self.num_required_cols = self.build_spec['num_required_cols']
-    self.num_optional_cols = self.build_spec['num_optional_cols']
+    self.use_tabs = self.build_spec['use_tabs']
+
+    self.num_default_cols = self.build_spec.get('num_default_cols')
+    self.num_cols_dict = self.build_spec['num_cols_dict']
 
     self.text_states = {
       States.CONFIGURING: {
@@ -187,13 +198,11 @@ class MyModel(object):
       }
     }
 
-  @property
-  def required_args(self):
-    return self.argument_groups[self.active_group].required_args
+  def args(self, group):
+    return self.argument_groups[self.active_group].arguments_dict[group]
 
-  @property
-  def optional_args(self):
-    return self.argument_groups[self.active_group].optional_args
+  def groups(self):
+    return self.argument_groups[self.active_group].arguments_dict.keys()
 
   def update_state(self, state):
     self.current_state = state
@@ -206,34 +215,51 @@ class MyModel(object):
     # TODO: fix skipping_config.. whatever that did
     # currently breaks when you supply it as a decorator option
     # return self.skipping_config() and self.required_section_complete()
-    return self.is_required_section_complete()
+    return self.are_required_arguments_present()
 
   def skipping_config(self):
     return self.build_spec['manual_start']
 
-  def is_required_section_complete(self):
+  def are_required_arguments_present(self):
     error_found = False
-    for arg in self.required_args:
-      widget = arg.widget_instance.widget_pack.widget
-      if arg.value:
-        widget.SetBackgroundColour(wx.NullColour)
-      else:
-        if not error_found:
-          error_found = True
-          widget.SetFocus()
-        widget.SetBackgroundColour("#EF9A9A")
-
-      widget.Refresh()
+    if self.use_argparse_groups:
+      index = 0
+      for group in self.groups():
+        for arg in self.args(group):
+          if arg.required and arg.nargs not in ['?', '*']:
+            error_found |= not self.is_required_argument_present(arg, index if self.use_tabs else None, error_found)
+        if self.args(group):
+          index += 1
+    else:
+      for arg in self.args("required arguments"):
+        error_found |= not self.is_required_argument_present(arg, 0 if self.use_tabs else None, error_found)
 
     return not error_found
 
+  @staticmethod
+  def is_required_argument_present(arg, index, error_found):
+    widget = arg.widget_instance.widget_pack.widget
+    if arg.value:
+      widget.SetBackgroundColour(wx.NullColour)
+      return True
+    else:
+      if not error_found:
+        error_found = True
+
+        if index is not None:
+          widget.Parent.Parent.Parent.SetSelection(index)
+        widget.SetFocus()
+      widget.SetBackgroundColour("Red")
+      return False
+
   def build_command_line_string(self):
-    optional_args = [arg.value for arg in self.optional_args]
-    required_args = [c.value for c in self.required_args if c.commands]
-    position_args = [c.value for c in self.required_args if not c.commands]
+    arguments_dict = self.argument_groups[self.active_group].arguments_dict
+    all_args = list(chain.from_iterable(arguments_dict.values()))
+    optional_args = [arg.value for arg in all_args if arg.commands]
+    position_args = [arg.value for arg in all_args if not arg.commands]
     if position_args:
       position_args.insert(0, "--")
-    cmd_string = ' '.join(list(filter(None, chain(required_args, optional_args, position_args))))
+    cmd_string = ' '.join(list(filter(None, chain(optional_args, position_args))))
     if self.layout_type == 'column':
       cmd_string = u'{} {}'.format(self.argument_groups[self.active_group].command, cmd_string)
     return u'{} --ignore-gooey {}'.format(self.build_spec['target'], cmd_string)
@@ -260,7 +286,8 @@ class MyModel(object):
       self.maybe_unpack(details, 'default'),
       self.maybe_unpack(details, 'nargs'),
       self.maybe_unpack(details, 'commands'),
-      self.maybe_unpack(details, 'choices')
+      self.maybe_unpack(details, 'choices'),
+      self.maybe_unpack(details, 'required')
     )
 
   @staticmethod

--- a/gooey/gui/presenter.py
+++ b/gooey/gui/presenter.py
@@ -33,10 +33,12 @@ class Presenter(object):
 
     pub.subscribe(self.on_selection_change, events.LIST_BOX)
 
-
   def on_selection_change(self, selection):
-    self.update_model()
+    self.delete_model()
     self.model.active_group = selection
+    self.create_model()
+    self.view.do_layout()
+    self.update_model()
     self.redraw_from_model()
     self.syncronize_from_model()
 
@@ -44,10 +46,8 @@ class Presenter(object):
     self.view.window_title = self.model.program_name
     self.view.window_size = self.model.default_size
 
-    self.view.required_section.clear()
-    self.view.optional_section.clear()
-    self.view.required_section.populate(self.model.required_args, self.model.num_required_cols)
-    self.view.optional_section.populate(self.model.optional_args, self.model.num_optional_cols)
+    self.create_model()
+    self.view.do_layout()
 
     if self.model.use_monospace_font:
       self.view.set_display_font_style('monospace')
@@ -65,9 +65,23 @@ class Presenter(object):
       self.on_start()
     self.syncronize_from_model()
 
+  def create_model(self):
+    for group in self.model.groups():
+      if self.model.args(group):
+        self.view.create_section(group)
+        self.view.section(group).clear()
+        self.view.section(group).populate(self.model.args(group), self.model.num_cols_dict.get(group, self.model.num_default_cols))
+
+  def delete_model(self):
+    for group in self.model.groups():
+      if self.model.args(group):
+        self.view.delete_section(group)
+
   def update_model(self):
-    self.update_list(self.model.required_args, self.view.required_section.get_values())
-    self.update_list(self.model.optional_args, self.view.optional_section.get_values())
+    for group in self.model.groups():
+      if self.model.args(group):
+        self.update_list(self.model.args(group), self.view.section(group).get_values())
+
     self.syncronize_from_model()
 
   def syncronize_from_model(self):
@@ -81,20 +95,21 @@ class Presenter(object):
     self.view.heading_subtitle = self.model.heading_subtitle
 
     # refresh the widgets
-    for index, widget in enumerate(self.view.required_section):
-      widget.set_value(self.model.required_args[index]._value)
-    for index, widget in enumerate(self.view.optional_section):
-      widget.set_value(self.model.optional_args[index]._value)
+    for group in self.model.groups():
+      if self.model.args(group):
+        for index, widget in enumerate(self.view.section(group)):
+          widget.set_value(self.model.args(group)[index]._value)
 
     # swap the views
     getattr(self, self.model.current_state)()
 
   def redraw_from_model(self):
     self.view.freeze()
-    self.view.required_section.clear()
-    self.view.optional_section.clear()
-    self.view.required_section.populate(self.model.required_args, self.model.num_required_cols)
-    self.view.optional_section.populate(self.model.optional_args, self.model.num_optional_cols)
+    for group in self.model.groups():
+      if self.model.args(group):
+        self.view.section(group).clear()
+        self.view.section(group).populate(self.model.args(group), self.model.num_cols_dict.get(group, self.model.num_default_cols))
+
     getattr(self, self.model.current_state)()
     self.view.thaw()
 

--- a/gooey/gui/widgets/components.py
+++ b/gooey/gui/widgets/components.py
@@ -51,6 +51,7 @@ class BaseGuiComponent(object):
     vertical_container.Add(core_widget_set, 0, wx.EXPAND)
     self.panel.SetSizer(vertical_container)
 
+    self.panel.Bind(wx.EVT_SIZE, self.onResize)
     return self.panel
 
   def bind(self, *args, **kwargs):

--- a/gooey/gui/windows/base_window.py
+++ b/gooey/gui/windows/base_window.py
@@ -22,13 +22,14 @@ class BaseWindow(wx.Frame):
   Primary Frame under which all sub-Panels are organized.
   '''
 
-  def __init__(self, layout_type):
+  def __init__(self, layout_type, use_tabs):
     wx.Frame.__init__(self, parent=None, id=-1)
 
     self.SetDoubleBuffered(True)
 
     # type of gui to render
     self.layout_type = layout_type
+    self.use_tabs = use_tabs
 
     # Components
     self.icon = None
@@ -77,13 +78,17 @@ class BaseWindow(wx.Frame):
   def heading_subtitle(self, text):
     self.head_panel.subtitle = text
 
-  @property
-  def required_section(self):
-    return self.config_panel.main_content.required_section
+  def create_section(self, name):
+    self.config_panel.main_content.CreateSection(name)
 
-  @property
-  def optional_section(self):
-    return self.config_panel.main_content.optional_section
+  def delete_section(self, name):
+    self.config_panel.main_content.DeleteSection(name)
+
+  def do_layout(self):
+    self.config_panel.main_content._do_layout()
+
+  def section(self, name):
+    return self.config_panel.main_content.Section(name)
 
   @property
   def progress_bar(self):

--- a/gooey/gui/windows/footer.py
+++ b/gooey/gui/windows/footer.py
@@ -104,9 +104,3 @@ class Footer(wx.Panel):
 
   def _load_image(self, img_path, height=70):
     return imageutil.resize_bitmap(self, imageutil._load_image(img_path), height)
-
-
-
-
-
-

--- a/gooey/gui/windows/layouts.py
+++ b/gooey/gui/windows/layouts.py
@@ -29,7 +29,7 @@ class FlatLayout(wx.Panel):
     super(FlatLayout, self).__init__(*args, **kwargs)
     self.SetDoubleBuffered(True)
 
-    self.main_content = ConfigPanel(self, opt_cols=3)
+    self.main_content = ConfigPanel(self, opt_cols=3, use_tabs=args[0].use_tabs)
 
     sizer = wx.BoxSizer(wx.HORIZONTAL)
     sizer.Add(self.main_content, 3, wx.EXPAND)
@@ -42,7 +42,7 @@ class ColumnLayout(wx.Panel):
     self.SetDoubleBuffered(True)
 
     self.sidebar = Sidebar(self)
-    self.main_content = ConfigPanel(self, opt_cols=2)
+    self.main_content = ConfigPanel(self, opt_cols=2, use_tabs=args[0].use_tabs)
 
     sizer = wx.BoxSizer(wx.HORIZONTAL)
     sizer.Add(self.sidebar, 1, wx.EXPAND)

--- a/gooey/python_bindings/config_generator.py
+++ b/gooey/python_bindings/config_generator.py
@@ -23,8 +23,6 @@ def create_from_parser(parser, source_path, **kwargs):
     'auto_start':           kwargs.get('auto_start', False),
     'show_advanced':        kwargs.get('advanced', True),
     'default_size':         kwargs.get('default_size', (610, 530)),
-    'num_required_cols':    kwargs.get('required_cols', 1),
-    'num_optional_cols':    kwargs.get('optional_cols', 3),
     'manual_start':         False,
     'layout_type':          'flat',
     'monospace_display':    kwargs.get('monospace_display', False),
@@ -34,13 +32,22 @@ def create_from_parser(parser, source_path, **kwargs):
     'progress_expr':        kwargs.get('progress_expr'),
     'disable_progress_bar_animation': kwargs.get('disable_progress_bar_animation'),
     'disable_stop_button':  kwargs.get('disable_stop_button'),
-    'group_by_type':        kwargs.get('group_by_type', True)
+    'group_by_type':        kwargs.get('group_by_type', True),
+    'use_argparse_groups':  kwargs.get('use_argparse_groups', False),
+    'use_tabs':             kwargs.get('use_tabs', False)
   }
+
+  if build_spec['use_argparse_groups']:
+    build_spec['num_default_cols'] = kwargs.get('default_cols', 2)
+    build_spec['num_cols_dict'] = kwargs.get('cols_dict', {})
+  else:
+    build_spec['num_cols_dict'] = {"required arguments": kwargs.get('required_cols', 1),
+                                   "optional arguments": kwargs.get('optional_cols', 3)}
 
   if not auto_start:
     build_spec['program_description'] = parser.description or build_spec['program_description']
 
-    layout_data = argparse_to_json.convert(parser) if build_spec['show_advanced'] else layouts.basic_config.items()
+    layout_data = argparse_to_json.convert(parser, build_spec['use_argparse_groups']) if build_spec['show_advanced'] else layouts.basic_config.items()
     build_spec.update(layout_data)
 
   return build_spec

--- a/gooey/python_bindings/gooey_decorator.py
+++ b/gooey/python_bindings/gooey_decorator.py
@@ -27,6 +27,8 @@ def Gooey(f=None,
           default_size=(610, 530),
           required_cols=2,
           optional_cols=2,
+          default_cols=2,
+          cols_dict={},
           dump_build_config=False,
           load_build_config=None,
           monospace_display=False, # TODO: add this to the docs
@@ -36,7 +38,9 @@ def Gooey(f=None,
           progress_expr=None, # TODO: add this to the docs
           disable_progress_bar_animation=False,
           disable_stop_button=False,
-          group_by_type=True): # TODO: add this to the docs
+          group_by_type=True, # TODO: add this to the docs
+          use_argparse_groups=False,
+          use_tabs=False):
   '''
   Decorator for client code's main function.
   Serializes argparse data to JSON for use with the Gooey front end

--- a/gooey/python_bindings/gooey_parser.py
+++ b/gooey/python_bindings/gooey_parser.py
@@ -22,7 +22,6 @@ class GooeyArgumentGroup(_ArgumentGroup):
         self.parser._actions[-1].metavar = metavar
         self.widgets[self.parser._actions[-1].dest] = widget
 
-
 class GooeyMutuallyExclusiveGroup(_MutuallyExclusiveGroup):
     def __init__(self, parser, widgets, *args, **kwargs):
         self.parser = parser
@@ -74,8 +73,8 @@ class GooeyParser(object):
         return group
 
     def add_argument_group(self, *args, **kwargs):
-        group = GooeyArgumentGroup(self.parser, self.widgets, **kwargs)
-        self.parser.add_argument_group(*args, **kwargs)
+        group = GooeyArgumentGroup(self.parser, self.widgets, *args, **kwargs)
+        self.parser._action_groups.append(group)
         return group
 
     def parse_args(self, args=None, namespace=None):


### PR DESCRIPTION
This pull request adds functionality to group arguments according to argparse groups, rather than the fixed groups `required arguments` and `optional arguments`. With this change, I find that I can now make pretty and usable GUIs for Python scripts with many arguments.

Specifying the argument `use_argparse_groups` to the Gooey wrapper invokes this new functionality - otherwise the operation should remain completely unchanged. Related arguments are `default_cols` which specifies the default number of columns, and `cols_dict` which allows the number of columns to be specified per group.

Note that to work properly, this pull request needs to be  merged with #210, since it is no longer immediately obvious which arguments are required and which are optional, and #209, since the previous version didn't handle optional positional arguments at all.