### PR TITLE
Kill child processes as well as shell process

### DIFF
--- a/gooey/gui/util/taskkill.py
+++ b/gooey/gui/util/taskkill.py
@@ -7,5 +7,9 @@ if sys.platform.startswith("win"):
   def taskkill(pid):
     os.system('taskkill /F /PID {:d} /T >NUL 2>NUL'.format(pid))
 else:  # POSIX
+  import psutil
   def taskkill(pid):
-    os.kill(pid, signal.SIGTERM)
+    parent = psutil.Process(pid)
+    for child in parent.children(recursive=True):
+      child.kill()
+    parent.kill()


### PR DESCRIPTION
Stopping a running script fails under Linux because only the shell process is stopped. This pull request makes the `Stop` button also kill all its child processes, notably the Python process itself, but also any children it may have created.