### PR TITLE
set stdout encoding utf-8

### DIFF
--- a/gooey/gui/processor.py
+++ b/gooey/gui/processor.py
@@ -38,6 +38,7 @@ class ProcessController(object):
   def run(self, command):
     env = os.environ.copy()
     env["GOOEY"] = "1"
+    env["PYTHONIOENCODING"] = "utf-8"
     try:
       self._process = subprocess.Popen(
         command.encode(sys.getfilesystemencoding()),


### PR DESCRIPTION
set this env to let it correct display result in Non-English language system。
my situation is in this issue: https://github.com/chriskiehl/Gooey/issues/230