### PR TITLE
Add "run_on_cli_callback" option to global configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Just about everything in Gooey's overall look and feel can be customized by pass
 | target | Tells Gooey how to re-invoke itself. By default Gooey will find python, but this allows you to specify the program (and arguments if supplied).|
 | program_name | The name displayed in the title bar of the GUI window. If not supplied, the title defaults to the script name pulled from `sys.argv[0]`. |
 | program_description | Sets the text displayed in the top panel of the `Settings` screen. Defaults to the description pulled from `ArgumentParser`. |
-| run_on_cli | Parse arguments from GUI and calls supplied function on cli(terminal) |
+| run_on_cli_callback | Parse arguments from GUI and calls this callback function on cli(terminal). The callback function takes two parameters(positional_args, optional_args) |
 | default_size | Initial size of the window | 
 | required_cols | Controls how many columns are in the Required Arguments section <br> :warning: **Deprecation notice:** See [Group Parameters](#group-configuration) for modern layout controls|
 | optional_cols | Controls how many columns are in the Optional Arguments section <br> :warning: **Deprecation notice:** See [Group Parameters](#group-configuration) for modern layout controls|

--- a/README.md
+++ b/README.md
@@ -244,8 +244,9 @@ Just about everything in Gooey's overall look and feel can be customized by pass
 | auto_start | Skips the configuration all together and runs the program immediately |
 | language | Tells Gooey which language set to load from the `gooey/languages` directory.|
 | target | Tells Gooey how to re-invoke itself. By default Gooey will find python, but this allows you to specify the program (and arguments if supplied).|
-|program_name | The name displayed in the title bar of the GUI window. If not supplied, the title defaults to the script name pulled from `sys.argv[0]`. |
+| program_name | The name displayed in the title bar of the GUI window. If not supplied, the title defaults to the script name pulled from `sys.argv[0]`. |
 | program_description | Sets the text displayed in the top panel of the `Settings` screen. Defaults to the description pulled from `ArgumentParser`. |
+| run_on_cli | Parse arguments from GUI and calls supplied function on cli(terminal) |
 | default_size | Initial size of the window | 
 | required_cols | Controls how many columns are in the Required Arguments section <br> :warning: **Deprecation notice:** See [Group Parameters](#group-configuration) for modern layout controls|
 | optional_cols | Controls how many columns are in the Optional Arguments section <br> :warning: **Deprecation notice:** See [Group Parameters](#group-configuration) for modern layout controls|

--- a/gooey/python_bindings/config_generator.py
+++ b/gooey/python_bindings/config_generator.py
@@ -46,6 +46,7 @@ def create_from_parser(parser, source_path, **kwargs):
         'show_success_modal':   kwargs.get('show_success_modal', True),
         'force_stop_is_error':  kwargs.get('force_stop_is_error', True),
         'poll_external_updates':kwargs.get('poll_external_updates', False),
+        'run_on_cli_callback':  kwargs.get('run_on_cli_callback', None),
 
         # Legacy/Backward compatibility interop
         'use_legacy_titles':    kwargs.get('use_legacy_titles', True),

--- a/gooey/python_bindings/gooey_decorator.py
+++ b/gooey/python_bindings/gooey_decorator.py
@@ -43,6 +43,7 @@ def Gooey(f=None,
           header_height=80,
           navigation='SIDEBAR', # TODO: add this to the docs
           tabbed_groups=False,
+          run_on_cli_callback=None,
           **kwargs):
   '''
   Decorator for client code's main function.


### PR DESCRIPTION
Some terminal-specific api calls(ex, curse.cbreak()) yields error and can't be adopted to current Gooey(wxPython) environment.
Receiving arguments from GUI and returning them to original process(mostly CLI) may resolve this issue, by supplying GUI just for getting arguments from user and calling callback function when "Start" button is clicked.