### PR TITLE
Relax dependency specification

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,12 +9,12 @@ with open('README.md') as readme:
 version = '1.0.0'
 
 deps = [
-    'Pillow==4.3.0',
-    'psutil==5.4.2'
+    'Pillow>=4.3.0',
+    'psutil>=5.4.2'
 ]
 
 if sys.version[0] == '3':
-    deps.append('wxpython==4.0.0b1')
+    deps.append('wxpython>=4.0.0b1')
 
 
 setup(


### PR DESCRIPTION
Make it possible to install more current package versions for psutil, pillow and wxpython. I am not sure of the best practice, I think you can also do this in `requirements.txt` (but I didn't use that one for installation).

Please test this change on your end. I could not wholly test this as some tests contain references to a [local file path](https://github.com/chriskiehl/Gooey/blob/b19fe8826dfae85c013506b4d49bbaee478e2006/gooey/tests/gooey_config__autostart.json#L11) (!), but at least some tests pass

Note: 
To make the whole thing work on Windows+Anaconda, I had to downgrade pillow to 4.1.1 fix some import problem (maybe this is https://github.com/python-pillow/Pillow/issues/2479). I think this is tangent to this PR as neither Pillow 4.3.0 nor pillow 5.0.0 imported correctly. I installed the other dependencies using `conda` before pip-installing gooey.