### PR TITLE
relax requirements.txt to allow for later versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-RXPY==0.1.0
-wxpython==4.0.0b1
-Pillow==4.3.0
-psutil==5.4.2
+RXPY>=0.1.0
+wxpython>=4.0.0b1
+Pillow>=4.3.0
+psutil>=5.4.2


### PR DESCRIPTION
Simple change to prevent pypi from stomping on required packages with later versions.