### PR TITLE
fallback when decoding errors happen

### DIFF
--- a/gooey/gui/processor.py
+++ b/gooey/gui/processor.py
@@ -63,7 +63,8 @@ class ProcessController(object):
             line = process.stdout.readline()
             if not line:
                 break
-            pub.send_message(events.CONSOLE_UPDATE, msg=line.decode(self.encoding))
+
+            pub.send_message(events.CONSOLE_UPDATE, msg=line.decode(self.encoding, 'replace'))
             pub.send_message(events.PROGRESS_UPDATE,
                              progress=self._extract_progress(line))
         pub.send_message(events.EXECUTION_COMPLETE)
@@ -74,7 +75,7 @@ class ProcessController(object):
         user-supplied regex and calculation instructions
         '''
         # monad-ish dispatch to avoid the if/else soup
-        find = partial(re.search, string=text.strip().decode(self.encoding))
+        find = partial(re.search, string=text.strip().decode(self.encoding, 'replace'))
         regex = unit(self.progress_regex)
         match = bind(regex, find)
         result = bind(match, self._calculate_progress)


### PR DESCRIPTION
I am using x86 Python 3.4 on Windows. The encoding for console output on englisch systems is cp1252 and not UTF-8. To get output when unexpected characters get decoded i added the 'replace' option sao the end user can see something. Maybe we need an option to set encoding for the ui and the console independently?