### PR TITLE
Fix config load

### DIFF
--- a/gooey/python_bindings/gooey_decorator.py
+++ b/gooey/python_bindings/gooey_decorator.py
@@ -73,7 +73,7 @@ def Gooey(f=None,
           **params)
 
       if dump_build_config:
-        config_path = os.path.join(os.getcwd(), 'gooey_config.json')
+        config_path = os.path.join(os.path.dirname(sys.argv[0]), 'gooey_config.json')
         print('Writing Build Config to: {}'.format(config_path))
         with open(config_path, 'w') as f:
           f.write(json.dumps(build_spec, indent=2))

--- a/gooey/python_bindings/gooey_decorator.py
+++ b/gooey/python_bindings/gooey_decorator.py
@@ -58,7 +58,9 @@ def Gooey(f=None,
       build_spec = None
       if load_build_config:
         try:
-          build_spec = json.load(open(load_build_config, "r"))
+          exec_dir = os.path.dirname(sys.argv[0])
+          open_path = os.path.join(exec_dir,load_build_config)
+          build_spec = json.load(open(open_path, "r"))
         except Exception as e:
           print( 'Exception loading Build Config from {0}: {1}'.format(load_build_config, e))
           sys.exit(1)


### PR DESCRIPTION
I was having issues when running my python scripts with specific python versions and with full file paths.
For example, something like: 
C:/Users/sodwyer/AppData/Local/Programs/Python/Python36-32\python.exe D:/Path/To/Project/proj_script.py

The JSON config file would fail to load, and the dumped config file would be dumped into the directory where python.exe was run from.

I made a couple of changes so that the folder of the current script is used instead. It seems to work ok for my use case but maybe it's not desired? Also, I didnt see any open issues about this so maybe it's a real edge case. Thought I'd pull request anyway just in case.

Let me know, thanks