### PR TITLE
Update to wxpython >=4.0.2 #323

### DIFF
--- a/gooey/gui/events.py
+++ b/gooey/gui/events.py
@@ -7,20 +7,19 @@ that tie everything together.
 
 import wx
 
-WINDOW_STOP     = wx.NewId()
-WINDOW_CANCEL   = wx.NewId()
-WINDOW_CLOSE    = wx.NewId()
-WINDOW_START    = wx.NewId()
-WINDOW_RESTART  = wx.NewId()
-WINDOW_EDIT     = wx.NewId()
+WINDOW_STOP     = wx.NewIdRef()
+WINDOW_CANCEL   = wx.NewIdRef()
+WINDOW_CLOSE    = wx.NewIdRef()
+WINDOW_START    = wx.NewIdRef()
+WINDOW_RESTART  = wx.NewIdRef()
+WINDOW_EDIT     = wx.NewIdRef()
 
-WINDOW_CHANGE   = wx.NewId()
-PANEL_CHANGE    = wx.NewId()
-LIST_BOX        = wx.NewId()
+WINDOW_CHANGE   = wx.NewIdRef()
+PANEL_CHANGE    = wx.NewIdRef()
+LIST_BOX        = wx.NewIdRef()
 
-CONSOLE_UPDATE  = wx.NewId()
-EXECUTION_COMPLETE = wx.NewId()
-PROGRESS_UPDATE = wx.NewId()
+CONSOLE_UPDATE  = wx.NewIdRef()
+EXECUTION_COMPLETE = wx.NewIdRef()
+PROGRESS_UPDATE = wx.NewIdRef()
 
-USER_INPUT = wx.NewId()
-
+USER_INPUT = wx.NewIdRef()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 RXPY>=0.1.0
-wxpython>=4.0.0b1
+wxpython>=4.0.2
 Pillow>=4.3.0
 psutil>=5.4.2

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ deps = [
 ]
 
 if sys.version[0] == '3':
-    deps.append('wxpython>=4.0.0b1')
+    deps.append('wxpython>=4.0.2')
 
 
 setup(


### PR DESCRIPTION
Fixing #323 in order to accommodate the new `wxpyton` versions and deprications of `wx.NewId()`