### PR TITLE
Avoid importing wx when --ignore-gooey is part of the command line

### DIFF
--- a/gooey/python_bindings/gooey_decorator.py
+++ b/gooey/python_bindings/gooey_decorator.py
@@ -11,7 +11,6 @@ import os
 import sys
 from argparse import ArgumentParser
 
-from gooey.gui import application
 from gooey.gui.util.freeze import getResourcePath
 from gooey.util.functional import merge
 from . import config_generator
@@ -53,6 +52,8 @@ def Gooey(f=None,
 
   def build(payload):
     def run_gooey(self, args=None, namespace=None):
+      # This import is delayed so it is not in the --ignore-gooey codepath.
+      from gooey.gui import application
       source_path = sys.argv[0]
 
       build_spec = None


### PR DESCRIPTION
As requested, this is a rebase of https://github.com/chriskiehl/Gooey/pull/331 on the 1.0.3-release branch. I also added a comment as requested.

# The problem this PR is trying to solve

I built an application that uses Gooey to generate its user interface. It has been working very well on my development machine, both in gui and cli mode. However, when I tried to use the application on a headless server, I got the following error:
 ```
ImportError: libgtk-3.so.0: cannot open shared object file: No such file or directory
```
Of couse, gtk is not installed on this server and I did not expect to use any of the graphical features of gooey on this machine. But as gooey allows the applications to be used in cli mode (using the --ignore-gooey switch), I would expect it to gracefully degrade its functionalities and require the graphical backend only when the graphical mode is used. This would allow client applications to be more versatile and better adapt to their environment.

# The PR content

The PR itself is quite simple, I removed the transitive inclusion of wx from the --ignore-gooey codepath and lazily imported it at the beginning of the pure graphical codepath.