### PR TITLE
Add parameter clear_before_run that forces console clear between runs.

### DIFF
--- a/gooey/gui/components/console.py
+++ b/gooey/gui/components/console.py
@@ -65,6 +65,12 @@ class Console(wx.Panel):
         """
         self.textbox.AppendText(txt)
 
+    def clear(self):
+        """
+            Clear the the main TextCtrl.
+        """
+        self.textbox.Clear()
+
 
     def getText(self):
         return self.textbox.GetValue()

--- a/gooey/gui/containers/application.py
+++ b/gooey/gui/containers/application.py
@@ -83,6 +83,8 @@ class GooeyApplication(wx.Frame):
             config = self.navbar.getActiveConfig()
             config.resetErrors()
             if config.isValid():
+                if self.buildSpec['clear_before_run']:
+                    self.console.clear()
                 self.clientRunner.run(self.buildCliString())
                 self.showConsole()
             else:

--- a/gooey/python_bindings/config_generator.py
+++ b/gooey/python_bindings/config_generator.py
@@ -50,6 +50,7 @@ def create_from_parser(parser, source_path, **kwargs):
       'show_restart_button':  kwargs.get('show_restart_button', True),
       'requires_shell':       kwargs.get('requires_shell', True),
       'menu':                 kwargs.get('menu', []),
+      'clear_before_run':     kwargs.get('clear_before_run', False),
 
       # Legacy/Backward compatibility interop
       'use_legacy_titles':    kwargs.get('use_legacy_titles', True),


### PR DESCRIPTION
If the parameter is set to yes in the gooey decorator, the console will be cleared before each run.

Current default parameter value is conservative and does not clear the console.