### PR TITLE
Allow hiding progress regex stdout from console

### DIFF
--- a/gooey/gui/components/menubar.py
+++ b/gooey/gui/components/menubar.py
@@ -3,7 +3,7 @@ from functools import partial
 
 import wx
 
-from gui import three_to_four
+from gooey.gui import three_to_four
 
 
 class MenuBar(wx.MenuBar):

--- a/gooey/gui/containers/application.py
+++ b/gooey/gui/containers/application.py
@@ -48,6 +48,7 @@ class GooeyApplication(wx.Frame):
         self.clientRunner = ProcessController(
             self.buildSpec.get('progress_regex'),
             self.buildSpec.get('progress_expr'),
+            self.buildSpec.get('hide_progress_msg'),
             self.buildSpec.get('encoding'),
             self.buildSpec.get('requires_shell'),
         )

--- a/gooey/gui/processor.py
+++ b/gooey/gui/processor.py
@@ -13,10 +13,12 @@ from gooey.util.functional import unit, bind
 
 
 class ProcessController(object):
-    def __init__(self, progress_regex, progress_expr, encoding, shell=True):
+    def __init__(self, progress_regex, progress_expr, hide_progress_msg,
+                 encoding, shell=True):
         self._process = None
         self.progress_regex = progress_regex
         self.progress_expr = progress_expr
+        self.hide_progress_msg = hide_progress_msg
         self.encoding = encoding
         self.wasForcefullyStopped = False
         self.shell_execution = shell
@@ -64,9 +66,11 @@ class ProcessController(object):
             line = process.stdout.readline()
             if not line:
                 break
-            pub.send_message(events.CONSOLE_UPDATE, msg=line.decode(self.encoding))
-            pub.send_message(events.PROGRESS_UPDATE,
-                             progress=self._extract_progress(line))
+            _progress = self._extract_progress(line)
+            pub.send_message(events.PROGRESS_UPDATE, progress=_progress)
+            if _progress is None or self.hide_progress_msg is False:
+                pub.send_message(events.CONSOLE_UPDATE,
+                                 msg=line.decode(self.encoding))
         pub.send_message(events.EXECUTION_COMPLETE)
 
     def _extract_progress(self, text):

--- a/gooey/python_bindings/config_generator.py
+++ b/gooey/python_bindings/config_generator.py
@@ -63,6 +63,7 @@ def create_from_parser(parser, source_path, **kwargs):
       'language_dir':         kwargs.get('language_dir'),
       'progress_regex':       kwargs.get('progress_regex'),
       'progress_expr':        kwargs.get('progress_expr'),
+      'hide_progress_msg':    kwargs.get('hide_progress_msg', False),
       'disable_progress_bar_animation': kwargs.get('disable_progress_bar_animation'),
       'disable_stop_button':  kwargs.get('disable_stop_button'),
 
@@ -81,6 +82,7 @@ def create_from_parser(parser, source_path, **kwargs):
       'header_image_center':  kwargs.get('header_image_center', False),
       'footer_bg_color':      kwargs.get('footer_bg_color', '#f0f0f0'),
       'sidebar_bg_color':     kwargs.get('sidebar_bg_color', '#f2f2f2'),
+
       # font family, weight, and size are determined at runtime
       'terminal_panel_color': kwargs.get('terminal_panel_color', '#F0F0F0'),
       'terminal_font_color':  kwargs.get('terminal_font_color', '#000000'),

--- a/gooey/python_bindings/gooey_decorator.py
+++ b/gooey/python_bindings/gooey_decorator.py
@@ -37,6 +37,7 @@ def Gooey(f=None,
           language_dir=getResourcePath('languages'),
           progress_regex=None,  # TODO: add this to the docs
           progress_expr=None,  # TODO: add this to the docs
+          hide_progress_msg=False,  # TODO: add this to the docs
           disable_progress_bar_animation=False,
           disable_stop_button=False,
           group_by_type=True,

--- a/gooey/tests/test_argparse_to_json.py
+++ b/gooey/tests/test_argparse_to_json.py
@@ -1,8 +1,8 @@
 import unittest
 from argparse import ArgumentParser
 from gooey import GooeyParser
-from python_bindings import argparse_to_json
-from util.functional import getin
+from gooey.python_bindings import argparse_to_json
+from gooey.util.functional import getin
 
 
 class TestArgparse(unittest.TestCase):

--- a/gooey/tests/test_formatters.py
+++ b/gooey/tests/test_formatters.py
@@ -1,7 +1,7 @@
 import argparse
 import unittest
 
-from gui import formatters
+from gooey.gui import formatters
 
 
 class TestFormatters(unittest.TestCase):

--- a/gooey/tests/test_processor.py
+++ b/gooey/tests/test_processor.py
@@ -9,27 +9,27 @@ class TestProcessor(unittest.TestCase):
     def test_extract_progress(self):
         # should pull out a number based on the supplied
         # regex and expression
-        processor = ProcessController("^progress: (\d+)%$", None, 'utf-8')
+        processor = ProcessController("^progress: (\d+)%$", None, False, 'utf-8')
         self.assertEqual(processor._extract_progress(b'progress: 50%'), 50)
 
-        processor = ProcessController("total: (\d+)%$", None,  'utf-8')
+        processor = ProcessController("total: (\d+)%$", None, False, 'utf-8')
         self.assertEqual(processor._extract_progress(b'my cool total: 100%'), 100)
 
 
     def test_extract_progress_returns_none_if_no_regex_supplied(self):
-        processor = ProcessController(None, None, 'utf-8')
+        processor = ProcessController(None, None, False, 'utf-8')
         self.assertIsNone(processor._extract_progress(b'Total progress: 100%'))
 
 
     def test_extract_progress_returns_none_if_no_match_found(self):
-        processor = ProcessController(r'(\d+)%$', None, 'utf-8')
+        processor = ProcessController(r'(\d+)%$', None, False, 'utf-8')
         self.assertIsNone(processor._extract_progress(b'No match in dis string'))
 
 
     def test_eval_progress(self):
         # given a match in the string, should eval the result
         regex = r'(\d+)/(\d+)$'
-        processor = ProcessController(regex, r'x[0] / x[1]', 'utf-8')
+        processor = ProcessController(regex, r'x[0] / x[1]', False, 'utf-8')
         match = re.search(regex, '50/50')
         self.assertEqual(processor._eval_progress(match), 1.0)
 
@@ -37,6 +37,6 @@ class TestProcessor(unittest.TestCase):
     def test_eval_progress_returns_none_on_failure(self):
         # given a match in the string, should eval the result
         regex = r'(\d+)/(\d+)$'
-        processor = ProcessController(regex, r'x[0] *^/* x[1]', 'utf-8')
+        processor = ProcessController(regex, r'x[0] *^/* x[1]', False, 'utf-8')
         match = re.search(regex, '50/50')
         self.assertIsNone(processor._eval_progress(match))


### PR DESCRIPTION
I have added a hide_progress_msg argument to the gooey decorator. If this 'hide_progress_msg' parameter is set to True , stdout which satisfies the progress_regex will only be used to update the progress bar and not be printed to the console. The current default parameter retains existing behavior. Let me know if there is a different name you'd like for the argument.

I also updated a couple imports in the tests and menubar.py to be absolute, however I'm not sure if those will cause any issues with Python 2.