### PR TITLE
Fix exclusive groups spacing.

### DIFF
--- a/gooey/gui/components/widgets/checkbox.py
+++ b/gooey/gui/components/widgets/checkbox.py
@@ -22,7 +22,6 @@ class CheckBox(TextContainer):
         layout = wx.BoxSizer(wx.VERTICAL)
         layout.Add(self.label)
         layout.AddSpacer(2)
-        layout.AddStretchSpacer(1)
         if self.help_text:
             hsizer = wx.BoxSizer(wx.HORIZONTAL)
             hsizer.Add(self.widget, 0)

--- a/gooey/gui/components/widgets/radio_group.py
+++ b/gooey/gui/components/widgets/radio_group.py
@@ -69,7 +69,7 @@ class RadioGroup(BaseWidget):
             sizer = wx.BoxSizer(wx.HORIZONTAL)
             sizer.Add(btn,0, wx.RIGHT, 4)
             sizer.Add(widget, 1, wx.EXPAND)
-            boxSizer.Add(sizer, 1, wx.ALL | wx.EXPAND, 5)
+            boxSizer.Add(sizer, 0, wx.ALL | wx.EXPAND, 5)
         self.SetSizer(boxSizer)
 
 


### PR DESCRIPTION
# The issue
I noticed that under certain conditions, gooey inserts big regions of empty space inside exclusive groups, especially when the different options have unbalanced content (ie a very short versus a very long help text). The issue can be observed in the following screen capture :

![full bug](https://user-images.githubusercontent.com/1778774/52779441-6f06b580-3048-11e9-8516-b5674f2fa041.png)

A minimal code example to reproduce this issue is available [in this gist.](https://gist.github.com/NathanRichard/4be3da7710a187e750a59ebb4bec464e)

# Fix rationale

The fix actually contains two one-line changes that each fix part of the issue. The most important one is to change the proportion parameter from 1 to 0 when adding the BoxSizer containing each individual exclusive option to the global RadioGroup container. Taken alone, this change already solves most of the issue, as can be seen in the following screen capture :

![box sizer proportion fix](https://user-images.githubusercontent.com/1778774/52779772-20a5e680-3049-11e9-9a1a-acb89a7daa0f.png)

According to the [WX documentation,](https://wxpython.org/Phoenix/docs/html/wx.Sizer.html#wx.Sizer.Add) the proportion parameter aim is to "weight" the free space distribution between the container elements when the container is scaled and elements alone cannot fill it.

Setting all children to 1 seems to result in WX forcing all children to use the same amount of space no matter if they need it or not. In our example, having an option that requires a lot of space due to its long help text forces the other one to use the same vertical space, resulting in wasted screen space an weird form presentation.

Setting the proportion to 0 is supposed to deactivate scaling, but in our case it does not prevent the biggest option to get all the space it needs while giving the smaller one only the necessary amount of vertical space.


The second change solves a spacing issue inside of the smallest option ; as can bee seen in the screen capture above, there is a bigger space between the option title and the description than between the description and the next option.
The final result is the following :

![full fix](https://user-images.githubusercontent.com/1778774/52781233-56000380-304c-11e9-9c3f-5f5fa948edbc.png)


