### PR TITLE
Fixing multiple mutually exclusive groups

### DIFF
--- a/gooey/python_bindings/argparse_to_json.py
+++ b/gooey/python_bindings/argparse_to_json.py
@@ -165,7 +165,7 @@ def reapply_mutex_groups(mutex_groups, action_groups):
                 # insert the _ArgumentGroup container
                 actions[targetindex] = mutexgroup
                 # remove the duplicated individual actions
-                return [action for action in actions
+                actions = [action for action in actions
                         if action not in mutex_actions]
         return actions
 


### PR DESCRIPTION
Previous version would only ever merge in the first mutually exclusive group into the action list.