### PR TITLE
Remove leftover reference to `type_arg_widget`.

### DIFF
--- a/gooey/python_bindings/argparse_to_json.py
+++ b/gooey/python_bindings/argparse_to_json.py
@@ -277,7 +277,7 @@ def categorize(actions, widget_dict, options):
 
 def get_widget(widgets, action, default):
     supplied_widget = widgets.get(action.dest, None)
-    return supplied_widget or type_arg_widget or default
+    return supplied_widget or default
 
 
 def is_required(action):


### PR DESCRIPTION
argparse_to_json.py:

    return supplied_widget or type_arg_widget or default