### PR TITLE
Fix issue 390 in argparse_to_json

### DIFF
--- a/gooey/python_bindings/argparse_to_json.py
+++ b/gooey/python_bindings/argparse_to_json.py
@@ -194,7 +194,10 @@ def categorize(actions, widget_dict, options):
             yield action_to_json(action, _get_widget(action, 'TextField'), options)
 
         elif is_choice(action):
-            yield action_to_json(action, _get_widget(action, 'Dropdown'), options)
+            _json = action_to_json(action, _get_widget(action, 'Dropdown'), options)
+            if 'choices' in _json['data']:
+                _json['data']['choices'] = list(_json['data']['choices'])
+            yield _json
 
         elif is_flag(action):
             yield action_to_json(action, _get_widget(action, 'CheckBox'), options)


### PR DESCRIPTION
Running the following code
```python
from gooey import Gooey, GooeyParser

@Gooey()
def main():
    parser = GooeyParser(description='Process some integers.')

    parser.add_argument(
        "--arg1",
        action="store",
        default="c1",
        choices=("c1", "c2", "c3"),
    )
    args = parser.parse_args()


if __name__ == '__main__':
    main()
```

produces an error

```
Traceback (most recent call last):
  File "issue.py", line 20, in <module>
    main()
  File "/Users/henriknf/miniconda3/lib/python3.7/site-packages/Gooey-1.0.2-py3.7.egg/gooey/python_bindings/gooey_decorator.py", line 83, in inner2
    return payload(*args, **kwargs)
  File "issue.py", line 16, in main
    args = parser.parse_args()
  File "/Users/henriknf/miniconda3/lib/python3.7/site-packages/Gooey-1.0.2-py3.7.egg/gooey/python_bindings/gooey_parser.py", line 113, in parse_args
    return self.parser.parse_args(args, namespace)
  File "/Users/henriknf/miniconda3/lib/python3.7/site-packages/Gooey-1.0.2-py3.7.egg/gooey/python_bindings/gooey_decorator.py", line 78, in run_gooey
    application.run(build_spec)
  File "/Users/henriknf/miniconda3/lib/python3.7/site-packages/Gooey-1.0.2-py3.7.egg/gooey/gui/application.py", line 15, in run
    app = build_app(build_spec)
  File "/Users/henriknf/miniconda3/lib/python3.7/site-packages/Gooey-1.0.2-py3.7.egg/gooey/gui/application.py", line 24, in build_app
    gapp = GooeyApplication(merge(build_spec, imagesPaths))
  File "/Users/henriknf/miniconda3/lib/python3.7/site-packages/Gooey-1.0.2-py3.7.egg/gooey/gui/containers/application.py", line 40, in __init__
    self.configs = self.buildConfigPanels(self)
  File "/Users/henriknf/miniconda3/lib/python3.7/site-packages/Gooey-1.0.2-py3.7.egg/gooey/gui/containers/application.py", line 206, in buildConfigPanels
    for widgets in self.buildSpec['widgets'].values()]
  File "/Users/henriknf/miniconda3/lib/python3.7/site-packages/Gooey-1.0.2-py3.7.egg/gooey/gui/containers/application.py", line 206, in <listcomp>
    for widgets in self.buildSpec['widgets'].values()]
  File "/Users/henriknf/miniconda3/lib/python3.7/site-packages/Gooey-1.0.2-py3.7.egg/gooey/gui/components/config.py", line 15, in __init__
    self.layoutComponent()
  File "/Users/henriknf/miniconda3/lib/python3.7/site-packages/Gooey-1.0.2-py3.7.egg/gooey/gui/components/config.py", line 80, in layoutComponent
    self.makeGroup(self, sizer, item, 0, wx.EXPAND)
  File "/Users/henriknf/miniconda3/lib/python3.7/site-packages/Gooey-1.0.2-py3.7.egg/gooey/gui/components/config.py", line 119, in makeGroup
    widget = self.reifyWidget(parent, item)
  File "/Users/henriknf/miniconda3/lib/python3.7/site-packages/Gooey-1.0.2-py3.7.egg/gooey/gui/components/config.py", line 159, in reifyWidget
    return widgetClass(parent, item)
  File "/Users/henriknf/miniconda3/lib/python3.7/site-packages/Gooey-1.0.2-py3.7.egg/gooey/gui/components/widgets/bases.py", line 53, in __init__
    self.widget = self.getWidget(self)
  File "/Users/henriknf/miniconda3/lib/python3.7/site-packages/Gooey-1.0.2-py3.7.egg/gooey/gui/components/widgets/dropdown.py", line 16, in getWidget
    choices=[default] + self._meta['choices'],
TypeError: can only concatenate list (not "tuple") to list
```

Here we make sure that choices in dropdown (if provided) is converted to a list.