### PR TITLE
Auto-URLs are confused by wide characters - close #427

### DIFF
--- a/gooey/gui/components/console.py
+++ b/gooey/gui/components/console.py
@@ -40,7 +40,7 @@ class Console(wx.Panel):
 
     def evtUrl(self, event):
         if event.MouseEvent.LeftUp():
-            webbrowser.open(self.textbox.GetValue()[event.URLStart:event.URLEnd])
+            webbrowser.open(self.textbox.GetRange(event.URLStart,event.URLEnd))
         event.Skip()
 
 


### PR DESCRIPTION
wxpython is explicit that you can't mix GetValue() and positions you get from other APIs.