### PR TITLE
change consts used for style

### DIFF
--- a/gooey/gui/components/widgets/richtextconsole.py
+++ b/gooey/gui/components/widgets/richtextconsole.py
@@ -38,7 +38,7 @@ class RichTextConsole(wx.richtext.RichTextCtrl):
     """
 
     def __init__(self, parent):
-        super(wx.richtext.RichTextCtrl, self).__init__(parent, -1, "", style=wx.TE_MULTILINE | wx.TE_READONLY)
+        super(wx.richtext.RichTextCtrl, self).__init__(parent, -1, "", style=wx.richtext.RE_MULTILINE | wx.richtext.RE_READONLY)
         self.esc = colored.style.ESC
         self.end = colored.style.END
         self.noop = lambda *args, **kwargs: None


### PR DESCRIPTION
Based on
https://wxpython.org/Phoenix/docs/html/wx.richtext.RichTextCtrl.html#wx.richtext.RichTextCtrl
the style constants used are wrong.