### PR TITLE
python 2 compatibility

### DIFF
--- a/gooey/gui/components/widgets/richtextconsole.py
+++ b/gooey/gui/components/widgets/richtextconsole.py
@@ -38,7 +38,7 @@ class RichTextConsole(wx.richtext.RichTextCtrl):
     """
 
     def __init__(self, parent):
-        super().__init__(parent, -1, "", style=wx.TE_MULTILINE | wx.TE_READONLY)
+        super(wx.richtext.RichTextCtrl, self).__init__(parent, -1, "", style=wx.TE_MULTILINE | wx.TE_READONLY)
         self.esc = colored.style.ESC
         self.end = colored.style.END
         self.noop = lambda *args, **kwargs: None


### PR DESCRIPTION
you can't use the rich text console with existing code. With this merge applied you can.

```
Traceback (most recent call last):
  File "tmpy.py", line 16, in <module>
    main()
  File "C:\users\eladeyal\source\repos\gooey\gooey\python_bindings\gooey_decorator.py", line 87, in inner2
    return payload(*args, **kwargs)
  File "tmpy.py", line 11, in main
    _ = GooeyParser().parse_args(sys.argv[1:])
  File "...\gooey\gooey\python_bindings\gooey_parser.py", line 114, in parse_args
    return self.parser.parse_args(args, namespace)
  File "...\gooey\gooey\python_bindings\gooey_decorator.py", line 82, in run_gooey
    application.run(build_spec)
  File "...\gooey\gooey\gui\application.py", line 16, in run
    app = build_app(build_spec)
  File "...\gooey\gooey\gui\application.py", line 25, in build_app
    gapp = GooeyApplication(merge(build_spec, imagesPaths))
  File "...\gooey\gooey\gui\containers\application.py", line 45, in __init__
    self.console = Console(self, buildSpec)
  File "...\gooey\gooey\gui\components\console.py", line 21, in __init__
    self.textbox = RichTextConsole(self)
  File "...\gooey\gooey\gui\components\widgets\richtextconsole.py", line 42, in __init__
    super().__init__(parent, -1, "", style=wx.richtext.RE_MULTILINE | wx.richtext.RE_READONLY)
TypeError: super() takes at least 1 argument (0 given)
```