### PR TITLE
allow control+scrollwheel to zoom rich text console

### DIFF
--- a/gooey/gui/components/widgets/richtextconsole.py
+++ b/gooey/gui/components/widgets/richtextconsole.py
@@ -57,6 +57,9 @@ class RichTextConsole(wx.richtext.RichTextCtrl):
             wxcolor = wx.Colour(int(hex[1:3],16), int(hex[3:5],16), int(hex[5:],16), alpha=wx.ALPHA_OPAQUE)
             # NB : we use a default parameter to force the evaluation of the binding
             self.actionsMap[escSeq] = lambda bindedColor=wxcolor: self.BeginTextColour(bindedColor)
+            
+        self.Bind(wx.EVT_MOUSEWHEEL, self.onMouseWheel)
+
 
     def AppendText(self, content):
         """
@@ -84,3 +87,15 @@ class RichTextConsole(wx.richtext.RichTextCtrl):
         # Invariant : unprocessed end of buffer is escape-free, ready to be printed
         self.WriteText(content[unprocIndex:])
         self.ShowPosition(self.GetInsertionPoint())
+
+    def onMouseWheel(self, event):
+        if event.GetModifiers()==2 and event.GetWheelAxis()==wx.MOUSE_WHEEL_VERTICAL:
+            if event.GetWheelRotation() >= event.GetWheelDelta():
+                r=1.1
+            elif event.GetWheelRotation() <= -event.GetWheelDelta():
+                r=1.0/1.1
+            else:
+                return
+            self.SetFontScale(self.GetFontScale() * r, True)
+        else:
+           event.Skip()


### PR DESCRIPTION
this addresses #432 

I tested on Windows 10 with python 2 and python 3 and it works nicely. I am suspicious if it will work the same on other platforms, because I read that the mouse wheel events are not consistent.