### PR TITLE
add accelerator

### DIFF
--- a/gooey/gui/containers/application.py
+++ b/gooey/gui/containers/application.py
@@ -64,6 +64,10 @@ class GooeyApplication(wx.Frame):
         pub.subscribe(events.PROGRESS_UPDATE, self.footer.updateProgressBar)
         # Top level wx close event
         self.Bind(wx.EVT_CLOSE, self.onClose)
+        
+        accel_tbl = wx.AcceleratorTable(
+            [(wx.ACCEL_CTRL,  wx.WXK_RETURN, events.WINDOW_START )])
+        self.SetAcceleratorTable(accel_tbl)
 
         if self.buildSpec['poll_external_updates']:
             self.fetchExternalUpdates()
@@ -81,16 +85,17 @@ class GooeyApplication(wx.Frame):
         Verify user input and kick off the client's program if valid
         """
         with transactUI(self):
-            config = self.navbar.getActiveConfig()
-            config.resetErrors()
-            if config.isValid():
-                if self.buildSpec['clear_before_run']:
-                    self.console.clear()
-                self.clientRunner.run(self.buildCliString())
-                self.showConsole()
-            else:
-                config.displayErrors()
-                self.Layout()
+            if not self.clientRunner.running():
+                config = self.navbar.getActiveConfig()
+                config.resetErrors()
+                if config.isValid():
+                    if self.buildSpec['clear_before_run']:
+                        self.console.clear()
+                    self.clientRunner.run(self.buildCliString())
+                    self.showConsole()
+                else:
+                    config.displayErrors()
+                    self.Layout()
 
 
     def onEdit(self):

--- a/gooey/gui/processor.py
+++ b/gooey/gui/processor.py
@@ -20,12 +20,16 @@ class ProcessController(object):
         self.progress_expr = progress_expr
         self.hide_progress_msg = hide_progress_msg
         self.encoding = encoding
+        self.wasSuccess = None
         self.wasForcefullyStopped = False
         self.shell_execution = shell
 
     def was_success(self):
-        self._process.communicate()
-        return self._process.returncode == 0
+        if self._process:
+            self._process.communicate()
+            self.wasSuccess=self._process.returncode == 0
+            self._process = None
+        return self.wasSuccess
 
     def poll(self):
         if not self._process:
@@ -34,13 +38,16 @@ class ProcessController(object):
 
     def stop(self):
         if self.running():
+            self.wasSuccess = False
             self.wasForcefullyStopped = True
             taskkill(self._process.pid)
+            self._process = None
 
     def running(self):
         return self._process and self.poll() is None
 
     def run(self, command):
+        self.wasSuccess = None
         self.wasForcefullyStopped = False
         env = os.environ.copy()
         env["GOOEY"] = "1"


### PR DESCRIPTION
CONTROL-ENTER for Start/restart

For that we change semantics of ProcessController.running() so now it's
True as long as the underlying app is running and False when it's done.

Then the accelarator can be dismissed if the ProcessController is
already active.

closes #437