### PR TITLE
Correct insignificant typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Different styling and functionality can be configured by passing arguments into 
            program_description,       # Defaults to ArgParse Description
            default_size=(610, 530),   # starting size of the GUI
            required_cols=1,           # number of columns in the "Required" section
-           optional_cols=2,           # number of columbs in the "Optional" section
+           optional_cols=2,           # number of columns in the "Optional" section
            dump_build_config=False,   # Dump the JSON Gooey uses to configure itself
            load_build_config=None,    # Loads a JSON Gooey-generated configuration
            monospace_display=False)   # Uses a mono-spaced font in the output screen
@@ -240,7 +240,7 @@ Just about everything in Gooey's overall look and feel can be customized by pass
 | Parameter | Summary | 
 |-----------|---------|
 | encoding | Text encoding to use when displaying characters (default: 'utf-8') | 
-| use_legacy_titles | Rewrites the default argparse group name from "Positional" to "Required". This is primarily for retaining backward compatibilty with previous versions of Gooey (which had poor support/awareness of groups and did its own naive bucketing of arguments). |
+| use_legacy_titles | Rewrites the default argparse group name from "Positional" to "Required". This is primarily for retaining backward compatibility with previous versions of Gooey (which had poor support/awareness of groups and did its own naive bucketing of arguments). |
 | advanced | Toggles whether to show the 'full' configuration screen, or a simplified version |
 | auto_start | Skips the configuration all together and runs the program immediately |
 | language | Tells Gooey which language set to load from the `gooey/languages` directory.|
@@ -380,7 +380,7 @@ Both views present each action in the `Argument Parser` as a unique GUI componen
 
 **Setting the layout style:**
 
-Currently, the layouts can't be explicitely specified via a parameter (on the TODO!). The layouts are built depending on whether or not there are `subparsers` used in your code base. So, if you want to trigger the `Column Layout`, you'll need to add a `subparser` to your `argparse` code. 
+Currently, the layouts can't be explicitly specified via a parameter (on the TODO!). The layouts are built depending on whether or not there are `subparsers` used in your code base. So, if you want to trigger the `Column Layout`, you'll need to add a `subparser` to your `argparse` code. 
 
 It can be toggled via the `advanced` parameter in the `Gooey` decorator. 
 
@@ -428,7 +428,7 @@ No Config pretty much does what you'd expect: it doesn't show a configuration sc
 
 
 >:warning: 
->Note! This functionality is experimental. Its API may be changed or removed alltogether. Feedback/thoughts on this feature is welcome and encouraged! 
+>Note! This functionality is experimental. Its API may be changed or removed altogether. Feedback/thoughts on this feature is welcome and encouraged! 
 
 Gooey can optionally do some basic pre-flight validation on user input. Internally, it uses these validator functions to check for the presence of required arguments. However, by using [GooeyParser](#gooeyparser), you can extend these functions with your own validation rules. This allows Gooey to show much, much more user friendly feedback before it hands control off to your program. 
 
@@ -492,9 +492,9 @@ With the validator in place, Gooey can present the error messages next to the re
 ## Using Dynamic Values
 
 >:warning: 
->Note! This functionality is experimental. Its API may be changed or removed alltogether. Feedback on this feature is welcome and encouraged! 
+>Note! This functionality is experimental. Its API may be changed or removed altogether. Feedback on this feature is welcome and encouraged! 
 
-Gooey's Choice style fields (Dropdown, Listbox) can be fed a dynamic set of values at runtime by enabling the `poll_external_updates` option. This will cause Gooey to request updated values from your program everytime the user visits the Configuration page. This can be used to, for instance, show the result of a previous execution on the config screen without requiring that the user restart the program. 
+Gooey's Choice style fields (Dropdown, Listbox) can be fed a dynamic set of values at runtime by enabling the `poll_external_updates` option. This will cause Gooey to request updated values from your program every time the user visits the Configuration page. This can be used to, for instance, show the result of a previous execution on the config screen without requiring that the user restart the program. 
 
 **How does it work?**
 
@@ -562,7 +562,7 @@ There are lots of options for telling Gooey about progress as your program is ru
 
 ## Customizing Icons
 
-Gooey comes with a set of six default icons. These can be overridden with your own custom images/icons by telling Gooey to search additional directories when initializing. This is done via the `image_dir` argument to the `Goeey` decorator. 
+Gooey comes with a set of six default icons. These can be overridden with your own custom images/icons by telling Gooey to search additional directories when initializing. This is done via the `image_dir` argument to the `Gooey` decorator. 
 
     @Gooey(program_name='Custom icon demo', image_dir='/path/to/my/image/directory')
     def main():


### PR DESCRIPTION
Fixed a few typos throughout the README, none of which where impacting the correctness of the content.