### PR TITLE
Change default button size for footer

### DIFF
--- a/gooey/gui/components/footer.py
+++ b/gooey/gui/components/footer.py
@@ -122,7 +122,7 @@ class Footer(wx.Panel):
         return wx.Button(
             parent=self,
             id=event_id,
-            size=(90, 24),
+            size=(90, 30),
             label=label,
             style=style)
 


### PR DESCRIPTION
Version: 1.0.3
OS: KUbuntu

I've changed default button size of the footer buttons as they are shown incomplete on my system.

Before change:
![button_before](https://user-images.githubusercontent.com/1113977/64938177-56b87c80-d85d-11e9-841c-bfccb48f7f9e.png)

After change:
![button_after](https://user-images.githubusercontent.com/1113977/64938183-591ad680-d85d-11e9-8e3d-6a18f5429c01.png)
