### PR TITLE
Extends the Dropdown widget to allow the use of stringifyable values and Falsy defaults

### DIFF
--- a/gooey/gui/components/widgets/bases.py
+++ b/gooey/gui/components/widgets/bases.py
@@ -56,7 +56,8 @@ class TextContainer(BaseWidget):
         self.setColors()
         self.SetSizer(self.layout)
         self.Bind(wx.EVT_SIZE, self.onSize)
-        if self._meta['default']:
+        # Checking for None instead of truthiness means False-evaluaded defaults can be used.
+        if self._meta['default'] is not None:
             self.setValue(self._meta['default'])
 
 

--- a/gooey/gui/components/widgets/dropdown.py
+++ b/gooey/gui/components/widgets/dropdown.py
@@ -12,8 +12,9 @@ class Dropdown(TextContainer):
         return wx.ComboBox(
             parent=parent,
             id=-1,
-            value=default,
-            choices=[default] + self._meta['choices'],
+            # str conversion allows using stringyfiable values in addition to pure strings
+            value=str(default),
+            choices=[str(default)] + [str(choice) for choice in self._meta['choices']],
             style=wx.CB_DROPDOWN)
 
     def setOptions(self, options):


### PR DESCRIPTION
The first commit of this PR allows the use of str-compatible objects as defaults and choices of the Dropdown widget. WX only accepts pure strings for these arguments, so the commit adds conversion calls at strategic points.

The second commit fixes a bug that prevents Falsy values from beeing used as defaults. This was probably not an issue without the first commit as only the empty string evaluates as False (but other objects with non-empty representations can evaluate to False and still be valid defaults).
[Here is a short code sample](https://gist.github.com/NathanRichard/3b8b4141b8d2991ef22d530f48876024) that illustrate the issue.

Bellow is a screenshot of the related bug:
![image](https://user-images.githubusercontent.com/1778774/68775645-20b23180-062f-11ea-8b76-48af82d2ee10.png)

And the same output with the fix:
![image](https://user-images.githubusercontent.com/1778774/68775801-5d7e2880-062f-11ea-8099-c56634a3124c.png)

