### PR TITLE
Implementation of a "collapsible" option to hide advanced options.

### DIFF
--- a/gooey/gui/components/collapsible_group.py
+++ b/gooey/gui/components/collapsible_group.py
@@ -1,0 +1,62 @@
+import wx
+from gooey.gui.util import wx_util
+from gooey.gui.components.util.wrapped_static_text import AutoWrappedStaticText
+
+class CollapsibleGroup(wx.CollapsiblePane):
+    def __init__(self, parent, groupName, groupDescription, showBorders, showUnderline, labelColor, descriptionColor, groupTopMargin):
+        super(CollapsibleGroup, self).__init__(parent, style=wx.CP_NO_TLW_RESIZE, label=groupName)
+        # In order to be visible even when collapsed, the group name must be but in the CollapsiblePane's label.
+        # To be consistant with the OptionGroups widget, h1 styling must be applied to the label,
+        #  and the only way is to apply it to the whole wx.CollapsiblePane.
+        # Widgets inherit the styles, so it means all childs would be h1.
+        # To avoid redefining each child separately, an intermediate Pannel is created and defined as h2 (default style).
+        # This intermediate Pannel is the one exposed in the interface so that children can inherit a proper type.
+        fontSize = self.GetFont().GetPointSize()
+        h1Font = wx.Font(fontSize * 1.2, *wx_util.styles['h1'])  # Equivalent to the StaticTexts created with h1().
+        h2Font = wx.Font(fontSize, *wx_util.styles['h2'])  # Equivalent to the StaticTexts created with h2().
+        self.SetFont(h1Font)
+        self.SetForegroundColour(labelColor)
+        if showBorders:
+            boxDetails = wx.StaticBox(self.GetPane(), -1, groupName)
+            self.firstLevelsizer = wx.StaticBoxSizer(boxDetails, wx.VERTICAL)
+        else:
+            self.firstLevelsizer = wx.BoxSizer(wx.VERTICAL)
+            self.firstLevelsizer.AddSpacer(10)
+        self.GetPane().SetSizer(self.firstLevelsizer)
+        
+        self.intermediateWindow = wx.Panel(self.GetPane())
+        self.intermediateWindow.SetFont(h2Font)
+        self.firstLevelsizer.Add(self.intermediateWindow, 0, wx.EXPAND | wx.LEFT, groupTopMargin)
+        self.secondLevelSizer = wx.BoxSizer(wx.VERTICAL)
+        self.intermediateWindow.SetSizer(self.secondLevelSizer)
+
+        # Invariant : getSizerForChilds() and getParentForChilds() produce valid results.
+
+        if groupDescription:
+            description = AutoWrappedStaticText(self.getParentForChilds(), label=groupDescription, target=self.getSizerForChilds())
+            description.SetForegroundColour(descriptionColor)
+            description.SetFont(h2Font)
+            self.getSizerForChilds().Add(description, 0,  wx.EXPAND | wx.LEFT, 10)
+
+        if not showBorders and groupName and showUnderline:
+            self.getSizerForChilds().Add(wx_util.horizontal_rule(self.getParentForChilds()), 0, wx.EXPAND | wx.LEFT, 10)
+
+        self.Bind(wx.EVT_COLLAPSIBLEPANE_CHANGED, self.on_change)
+
+    def on_change(self, event):
+        self.GetParent().Layout()
+
+    def getSizerForParent(self):
+        """
+        Returns the sizer which should be added to the higher level sizer.
+        """
+        return self.firstLevelsizer
+
+    def getParentForChilds(self):
+        """
+        Returns the sizer to which the child widgets should be added.
+        """
+        return self.intermediateWindow
+
+    def getSizerForChilds(self):
+        return self.secondLevelSizer

--- a/gooey/gui/components/options_group.py
+++ b/gooey/gui/components/options_group.py
@@ -1,0 +1,46 @@
+import wx
+from gooey.gui.util import wx_util
+from gooey.gui.components.util.wrapped_static_text import AutoWrappedStaticText
+
+class OptionsGroup:
+    def __init__(self, parent, groupName, groupDescription, showBorders, showUnderline, labelColor, descriptionColor, groupTopMargin):
+        # determine the type of border , if any, the main sizer will use
+        self.parent = parent
+        if showBorders:
+            boxDetails = wx.StaticBox(parent, -1, groupName)
+            self.sizer = wx.StaticBoxSizer(boxDetails, wx.VERTICAL)
+        else:
+            self.sizer = wx.BoxSizer(wx.VERTICAL)
+            self.sizer.AddSpacer(10)
+            if groupName:
+                groupNameWidget = wx_util.h1(parent, groupName)
+                groupNameWidget.SetForegroundColour(labelColor)
+                self.sizer.Add(groupNameWidget, 0, wx.TOP | wx.BOTTOM | wx.LEFT, 8)
+
+        # Invariant : getSizerForChilds() and getParentForChilds() produce valid results.
+        
+        if groupDescription:
+            description = AutoWrappedStaticText(self.getParentForChilds(), label=groupDescription, target=self.getSizerForChilds())
+            description.SetForegroundColour(descriptionColor)
+            self.getSizerForChilds().Add(description, 1,  wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 10)
+        # apply an underline when a grouping border is not specified
+        if not showBorders and groupName and showUnderline:
+            self.getSizerForChilds().Add(wx_util.horizontal_rule(parent), 0, wx.EXPAND | wx.LEFT, 10)
+
+        self.marginSizer = wx.BoxSizer(wx.VERTICAL)
+        self.marginSizer.Add(self.sizer, 1, wx.EXPAND | wx.TOP, groupTopMargin)
+    
+    def getSizerForParent(self):
+        """
+        Returns the sizer which should be added to the higher level sizer.
+        """
+        return self.marginSizer
+
+    def getSizerForChilds(self):
+        """
+        Returns the sizer to which the child widgets should be added.
+        """
+        return self.sizer
+
+    def getParentForChilds(self):
+        return self.parent

--- a/gooey/python_bindings/argparse_to_json.py
+++ b/gooey/python_bindings/argparse_to_json.py
@@ -82,7 +82,8 @@ def convert(parser, **kwargs):
         },
         'columns': 2,
         'padding': 10,
-        'show_border': False
+        'show_border': False,
+        'collapsible': False
     }
 
     assert_subparser_constraints(parser)


### PR DESCRIPTION
# The change
This change adds a new boolean group option called "collapsible".
When the option is set to True, the group arguments are wrapped in a CollapsiblePane which is folded at start.
This allows to expose avanced options to some users without complexifying too much the interface for average users.
By default, the option set to False to maintain legacy behavior.

# Screenshots
![image](https://user-images.githubusercontent.com/1778774/69074490-c7337380-0a2f-11ea-8fea-35a7a5d264fe.png)
![image](https://user-images.githubusercontent.com/1778774/69074515-d2869f00-0a2f-11ea-85df-34be964e098b.png)

Related PR for GooeyExamples : https://github.com/chriskiehl/GooeyExamples/pull/21/commits

# Testing
Initially this feature was developed for a 1.0.2-based application and then re-based to 1.0.4. I discovered after the rebase that I was not able to launch any Gooey application with the vanilla 1.0.4 branch, so I rebased a second time on the 1.0.3 (the changeset can actually be applied directly to both branches), and got it working both on my application and the GooeyExamples folder. I did not spot any regression during my testing.