### PR TITLE
closes 523 - add colorchooser widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ However, by dropping in `GooeyParser` and supplying a `widget` name, you can dis
 | PasswordField | <p align="center"><img src="https://github.com/chriskiehl/GooeyImages/raw/images/readme-images/28953722-eae72cca-788e-11e7-8fa1-9a1ef332a053.png" width="400"></p> |
 | Listbox | ![image](https://github.com/chriskiehl/GooeyImages/raw/images/readme-images/31590191-fadd06f2-b1c0-11e7-9a49-7cbf0c6d33d1.png) |
 | BlockCheckbox | ![image](https://github.com/chriskiehl/GooeyImages/raw/images/readme-images/46922288-9296f200-cfbb-11e8-8b0d-ddde08064247.png) <br/> The default InlineCheck box can look less than ideal if a large help text block is present. `BlockCheckbox` moves the text block to the normal position and provides a short-form `block_label` for display next to the control. Use `gooey_options.checkbox_label` to control the label text | 
-
+|  ColourChooser   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;| <p align="center"><img src="https://user-images.githubusercontent.com/21027844/72672451-0752aa80-3a0f-11ea-86ed-8303bd3e54b5.gif" width="400"></p> |
 
  
   

--- a/gooey/gui/components/widgets/choosers.py
+++ b/gooey/gui/components/widgets/choosers.py
@@ -7,7 +7,8 @@ __ALL__ = [
     'FileSaver',
     'DirChooser',
     'MultiDirChooser',
-    'DateChooser'
+    'DateChooser',
+    'ColourChooser'
 ]
 
 class FileChooser(BaseChooser):
@@ -29,6 +30,7 @@ class DirChooser(BaseChooser):
     # todo: allow wildcard
     widget_class = core.DirChooser
 
+
 class MultiDirChooser(BaseChooser):
     # todo: allow wildcard
     widget_class = core.MultiDirChooser
@@ -38,3 +40,6 @@ class DateChooser(BaseChooser):
     # todo: allow wildcard
     widget_class = core.DateChooser
 
+
+class ColourChooser(BaseChooser):
+    widget_class = core.ColourChooser

--- a/gooey/gui/components/widgets/core/__init__.py
+++ b/gooey/gui/components/widgets/core/__init__.py
@@ -1,2 +1,2 @@
-from . chooser import Chooser, FileChooser, FileSaver, DirChooser, DateChooser, MultiFileChooser, MultiDirChooser
+from . chooser import Chooser, FileChooser, FileSaver, DirChooser, DateChooser, MultiFileChooser, MultiDirChooser, ColourChooser
 from . text_input import PasswordInput, MultilineTextInput, TextInput

--- a/gooey/gui/components/widgets/core/chooser.py
+++ b/gooey/gui/components/widgets/core/chooser.py
@@ -120,7 +120,7 @@ class MultiDirChooser(Chooser):
 
 
 class DateChooser(Chooser):
-    """ Launches a date picker which returns and ISO Date """
+    """ Launches a date picker which returns an ISO Date """
     def __init__(self, *args, **kwargs):
         defaults = {'label': _('choose_date')}
         super(DateChooser, self).__init__(*args, **merge(kwargs, defaults))
@@ -130,6 +130,29 @@ class DateChooser(Chooser):
         return CalendarDlg(self)
 
 
+class ColourChooser(Chooser):
+    """ Launches a color picker which returns a hex color code"""
+    def __init__(self, *args, **kwargs):
+        defaults = {'label': _('choose_colour'),
+                    'style': wx.TE_RICH}
+        super(ColourChooser, self).__init__(*args, **merge(kwargs, defaults))
 
+    def setValue(self, value):
+        colour = wx.Colour(value)
+        self.widget.widget.SetForegroundColour(colour)
+        self.widget.widget.SetBackgroundColour(colour)
+        self.widget.setValue(value)
+
+    def getResult(self, dialog):
+        colour = dialog.GetColourData().GetColour()
+
+        # Set text box back/foreground to selected colour
+        self.widget.widget.SetForegroundColour(colour)
+        self.widget.widget.SetBackgroundColour(colour)
+
+        return colour.GetAsString(wx.C2S_HTML_SYNTAX)
+
+    def getDialog(self):
+        return wx.ColourDialog(self)
 
 

--- a/gooey/languages/english.json
+++ b/gooey/languages/english.json
@@ -2,6 +2,7 @@
   "browse": "Browse",
   "cancel": "Cancel",
   "checkbox_label": "Enable",
+  "choose_colour": "Choose Colour",
   "choose_date": "Choose Date",
   "choose_file": "Choose File",
   "choose_folder": "Choose Folder",

--- a/gooey/tests/all_widgets.py
+++ b/gooey/tests/all_widgets.py
@@ -68,6 +68,7 @@ def main():
     parser.add_argument("--filesaver", default="fs-value", widget='FileSaver')
     parser.add_argument("--dirchooser", default="dc-value", widget='DirChooser')
     parser.add_argument("--datechooser", default="2015-01-01", widget='DateChooser')
+    parser.add_argument("--colourchooser", default="#000000", widget='ColourChooser')
 
     dest_vars = [
         'textfield',
@@ -82,7 +83,8 @@ def main():
         'filechooser',
         'filesaver',
         'dirchooser',
-        'datechooser'
+        'datechooser',
+        'colourchooser'
 
     ]
 

--- a/gooey/tests/all_widgets_subparser.py
+++ b/gooey/tests/all_widgets_subparser.py
@@ -67,6 +67,7 @@ def main():
     parser_one.add_argument("--filesaver", default="fs-value", widget='FileSaver')
     parser_one.add_argument("--dirchooser", default="dc-value", widget='DirChooser')
     parser_one.add_argument("--datechooser", default="2015-01-01", widget='DateChooser')
+    parser_one.add_argument("--colourchooser", default="#000000", widget='ColourChooser')
 
     parser_two = subs.add_parser('parser2', prog="parser 2")
     parser_two.add_argument('--textfield', default=2, widget="TextField")
@@ -120,6 +121,7 @@ def main():
     parser_two.add_argument("--filesaver", default="fs-value", widget='FileSaver')
     parser_two.add_argument("--dirchooser", default="dc-value", widget='DirChooser')
     parser_two.add_argument("--datechooser", default="2015-01-01",widget='DateChooser')
+    parser_two.add_argument("--colourchooser", default="#000000", widget='ColourChooser')
 
     dest_vars = [
         'textfield',
@@ -134,7 +136,8 @@ def main():
         'filechooser',
         'filesaver',
         'dirchooser',
-        'datechooser'
+        'datechooser',
+        'colourchooser'
     ]
 
     parser.parse_args()
@@ -145,7 +148,6 @@ def main():
     for i in dest_vars:
         assert getattr(args, i) is not None
     print("Success")
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Closes https://github.com/chriskiehl/Gooey/issues/523, adds ColourChooser widget which returns hex color codes. I went with the spelling `Colour` in order to keep with wx conventions.

I can add an example to https://github.com/chriskiehl/GooeyExamples, once approved.

![colour_chooser_example](https://user-images.githubusercontent.com/21027844/72672451-0752aa80-3a0f-11ea-86ed-8303bd3e54b5.gif)