### PR TITLE
pass footer_bg_color from buildSpec to Footer

### DIFF
--- a/gooey/gui/components/footer.py
+++ b/gooey/gui/components/footer.py
@@ -90,6 +90,7 @@ class Footer(wx.Panel):
 
 
     def _do_layout(self):
+        self.SetBackgroundColour(self.buildSpec['footer_bg_color'])
         self.stop_button.Hide()
         self.restart_button.Hide()
 


### PR DESCRIPTION
The footer_bg_color specified wasn't getting passed to the Footer component (terminology?) at any point. The _do_layout method in Footer seems like a reasonable place to do so; anyway seems to work properly when I test.