### PR TITLE
Issue 554: Fix MultiFileChooser output formatting.

### DIFF
--- a/gooey/gui/components/widgets/choosers.py
+++ b/gooey/gui/components/widgets/choosers.py
@@ -4,6 +4,7 @@ from gooey.gui.components.widgets.bases import TextContainer, BaseChooser
 
 __ALL__ = [
     'FileChooser',
+    'MultiFileChooser',
     'FileSaver',
     'DirChooser',
     'MultiDirChooser',
@@ -19,6 +20,9 @@ class FileChooser(BaseChooser):
 class MultiFileChooser(BaseChooser):
     # todo: allow wildcard from argparse
     widget_class = core.MultiFileChooser
+
+    def formatOutput(self, metatdata, value):
+        return formatters.multiFileChooser(metatdata, value)
 
 
 class FileSaver(BaseChooser):

--- a/gooey/tests/test_formatters.py
+++ b/gooey/tests/test_formatters.py
@@ -1,4 +1,6 @@
 import argparse
+import os
+import shlex
 import unittest
 
 from gooey.gui import formatters
@@ -42,3 +44,46 @@ class TestFormatters(unittest.TestCase):
                 parser.add_argument('-v', '--verbose', action='count')
                 parser.parse_args(result.split())
 
+    def test_multifilechooser_formatter(self):
+        """
+        Should return files (quoted), separated by spaces if there is more
+        than one, preceeded by optional command if the argument is optional.
+
+        Assumes the argument has been created with some form of nargs, which
+        only makes sense for possibly choosing multiple values.
+        """
+
+        # Helper function to generalize the variants we need to test
+        def multifilechooser_helper(names):
+            # Note that the MultiFileChooser widget produces a single string with
+            # paths separated by os.pathsep.
+            if names:
+                prefix = names[0] + ' '
+            else:
+                prefix = ''
+
+            expected_outputs = [
+                (names, None, ''),
+                (names, prefix + '"abc"', 'abc'),
+                (names, prefix + '"abc" "def"', os.pathsep.join(['abc', 'def'])),
+                # paths with spaces
+                (names, prefix + '"a b c"', 'a b c'),
+                (names, prefix + '"a b c" "d e f"', os.pathsep.join(['a b c', 'd e f'])),
+            ]
+
+            for commands, expected, widget_result in expected_outputs:
+                result = formatters.multiFileChooser({'commands': commands}, widget_result)
+                self.assertEqual(result, expected)
+                # make sure that argparse actually accepts it as valid.
+                if result:
+                    parser = argparse.ArgumentParser()
+                    if not names:
+                        names = ["file"]
+                    parser.add_argument(names[0], nargs='+')
+                    parser.parse_args(shlex.split(result))
+
+        # Positional argument, with nargs
+        multifilechooser_helper([])
+
+        # Optional argument, with nargs
+        multifilechooser_helper(["-f", "--file"])


### PR DESCRIPTION
Issue: https://github.com/chriskiehl/Gooey/issues/544

The fix is done by using formatters.multiFileChooser as this chooser's formatOutput() rather than formatters.general.

Also adds MultiFileChooser to __ALL__.

Includes tests for formatters.multiFileChooser. I have assumed that arguments using the MultiFileChooser widget expect multiple values, and are therefore also configured with some form of nargs.

Other choosers may need similar fixes; I have not experimented with them.