### PR TITLE
Closes Issue #550

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ However, by dropping in `GooeyParser` and supplying a `widget` name, you can dis
 
 | Widget         |           Example            | 
 |----------------|------------------------------| 
-|  DirChooser, FileChooser, MultiFileChooser, FileSaver, MultiFileSaver   | <p align="center"><img src="https://github.com/chriskiehl/GooeyImages/raw/images/readme-images/f5483b28-07c5-11e5-9d01-1935635fc22d.gif" width="400"></p> | 
+|  DirChooser, MultiDirChooser, FileChooser, MultiFileChooser, FileSaver   | <p align="center"><img src="https://github.com/chriskiehl/GooeyImages/raw/images/readme-images/f5483b28-07c5-11e5-9d01-1935635fc22d.gif" width="400"></p> | 
 |  DateChooser   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;| <p align="center"><img src="https://github.com/chriskiehl/GooeyImages/raw/images/readme-images/f544756a-07c5-11e5-86d6-862ac146ad35.gif" width="400"></p> |
 | PasswordField | <p align="center"><img src="https://github.com/chriskiehl/GooeyImages/raw/images/readme-images/28953722-eae72cca-788e-11e7-8fa1-9a1ef332a053.png" width="400"></p> |
 | Listbox | ![image](https://github.com/chriskiehl/GooeyImages/raw/images/readme-images/31590191-fadd06f2-b1c0-11e7-9a49-7cbf0c6d33d1.png) |

--- a/gooey/gui/components/widgets/choosers.py
+++ b/gooey/gui/components/widgets/choosers.py
@@ -39,6 +39,9 @@ class MultiDirChooser(BaseChooser):
     # todo: allow wildcard
     widget_class = core.MultiDirChooser
 
+    def formatOutput(self, metatdata, value):
+        return formatters.multiFileChooser(metatdata, value)
+
 
 class DateChooser(BaseChooser):
     # todo: allow wildcard

--- a/gooey/gui/components/widgets/choosers.py
+++ b/gooey/gui/components/widgets/choosers.py
@@ -4,6 +4,7 @@ from gooey.gui.components.widgets.bases import TextContainer, BaseChooser
 
 __ALL__ = [
     'FileChooser',
+    'MultiFileChooser',
     'FileSaver',
     'DirChooser',
     'MultiDirChooser',
@@ -19,6 +20,9 @@ class FileChooser(BaseChooser):
 class MultiFileChooser(BaseChooser):
     # todo: allow wildcard from argparse
     widget_class = core.MultiFileChooser
+
+    def formatOutput(self, metatdata, value):
+        return formatters.multiFileChooser(metatdata, value)
 
 
 class FileSaver(BaseChooser):

--- a/gooey/tests/test_formatters.py
+++ b/gooey/tests/test_formatters.py
@@ -1,4 +1,6 @@
 import argparse
+import os
+import shlex
 import unittest
 
 from gooey.gui import formatters
@@ -42,3 +44,46 @@ class TestFormatters(unittest.TestCase):
                 parser.add_argument('-v', '--verbose', action='count')
                 parser.parse_args(result.split())
 
+    def test_multifilechooser_formatter(self):
+        """
+        Should return files (quoted), separated by spaces if there is more
+        than one, preceeded by optional command if the argument is optional.
+
+        Assumes the argument has been created with some form of nargs, which
+        only makes sense for possibly choosing multiple values.
+        """
+
+        # Helper function to generalize the variants we need to test
+        def multifilechooser_helper(names):
+            # Note that the MultiFileChooser widget produces a single string with
+            # paths separated by os.pathsep.
+            if names:
+                prefix = names[0] + ' '
+            else:
+                prefix = ''
+
+            expected_outputs = [
+                (names, None, ''),
+                (names, prefix + '"abc"', 'abc'),
+                (names, prefix + '"abc" "def"', os.pathsep.join(['abc', 'def'])),
+                # paths with spaces
+                (names, prefix + '"a b c"', 'a b c'),
+                (names, prefix + '"a b c" "d e f"', os.pathsep.join(['a b c', 'd e f'])),
+            ]
+
+            for commands, expected, widget_result in expected_outputs:
+                result = formatters.multiFileChooser({'commands': commands}, widget_result)
+                self.assertEqual(result, expected)
+                # make sure that argparse actually accepts it as valid.
+                if result:
+                    parser = argparse.ArgumentParser()
+                    if not names:
+                        names = ["file"]
+                    parser.add_argument(names[0], nargs='+')
+                    parser.parse_args(shlex.split(result))
+
+        # Positional argument, with nargs
+        multifilechooser_helper([])
+
+        # Optional argument, with nargs
+        multifilechooser_helper(["-f", "--file"])


### PR DESCRIPTION
Issue #550: MultiDirChooser cannot handle paths with spaces.

Fix: instead of the general formatter, use formatters.multiFileChooser, which handles spaces in paths without problems.