### PR TITLE
Fix Issue 550: MultiDirChooser cannot handle paths with spaces.

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ However, by dropping in `GooeyParser` and supplying a `widget` name, you can dis
 
 | Widget         |           Example            | 
 |----------------|------------------------------| 
-|  DirChooser, FileChooser, MultiFileChooser, FileSaver, MultiFileSaver   | <p align="center"><img src="https://github.com/chriskiehl/GooeyImages/raw/images/readme-images/f5483b28-07c5-11e5-9d01-1935635fc22d.gif" width="400"></p> | 
+|  DirChooser, MultiDirChooser, FileChooser, MultiFileChooser, FileSaver   | <p align="center"><img src="https://github.com/chriskiehl/GooeyImages/raw/images/readme-images/f5483b28-07c5-11e5-9d01-1935635fc22d.gif" width="400"></p> | 
 |  DateChooser   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;| <p align="center"><img src="https://github.com/chriskiehl/GooeyImages/raw/images/readme-images/f544756a-07c5-11e5-86d6-862ac146ad35.gif" width="400"></p> |
 | PasswordField | <p align="center"><img src="https://github.com/chriskiehl/GooeyImages/raw/images/readme-images/28953722-eae72cca-788e-11e7-8fa1-9a1ef332a053.png" width="400"></p> |
 | Listbox | ![image](https://github.com/chriskiehl/GooeyImages/raw/images/readme-images/31590191-fadd06f2-b1c0-11e7-9a49-7cbf0c6d33d1.png) |

--- a/gooey/gui/components/widgets/choosers.py
+++ b/gooey/gui/components/widgets/choosers.py
@@ -1,3 +1,4 @@
+from gooey.gui import formatters
 from gooey.gui.components.widgets import core
 from gooey.gui.components.widgets.bases import TextContainer, BaseChooser
 
@@ -34,6 +35,9 @@ class DirChooser(BaseChooser):
 class MultiDirChooser(BaseChooser):
     # todo: allow wildcard
     widget_class = core.MultiDirChooser
+
+    def formatOutput(self, metadata, value):
+        return formatters.multiFileChooser(metadata, value)
 
 
 class DateChooser(BaseChooser):


### PR DESCRIPTION
Issue #550: MultiDirChooser cannot handle paths with spaces.

Fix: Instead of using the general formatter, use formatters.multiFileChooser, which handles paths with spaces.

I don't how to do tests that rely on interacting with the GUI portion, but if you can point me at some, I'm happy to learn by example and add some.