### PR TITLE
Fix Issue 553: MultiDirChooser now handles Windows volume labels.

### DIFF
--- a/gooey/gui/components/widgets/core/chooser.py
+++ b/gooey/gui/components/widgets/core/chooser.py
@@ -1,7 +1,6 @@
 import wx
 import wx.lib.agw.multidirdialog as MDD
 import os
-import pathlib
 import re
 
 from gooey.gui.components.widgets.core.text_input import TextInput
@@ -123,11 +122,10 @@ class MultiDirChooser(Chooser):
         if 'nt' == os.name:
             for i, path in enumerate(paths):
                 if path:
-                    purepath = pathlib.PurePath(path)
-                    parts = purepath.parts
+                    parts = path.split(os.sep)
                     vol = parts[0]
                     drives = re.match(r'.*\((?P<drive>\w:)\)', vol)
-                    paths[i] = os.sep.join((drives.group('drive'),) + parts[1:])
+                    paths[i] = os.sep.join([drives.group('drive')] + parts[1:])
 
         return os.pathsep.join(paths)
 

--- a/gooey/gui/components/widgets/core/chooser.py
+++ b/gooey/gui/components/widgets/core/chooser.py
@@ -1,6 +1,8 @@
 import wx
 import wx.lib.agw.multidirdialog as MDD
 import os
+import pathlib
+import re
 
 from gooey.gui.components.widgets.core.text_input import TextInput
 from gooey.gui.components.widgets.dialogs.calender_dialog import CalendarDlg
@@ -82,7 +84,7 @@ class MultiFileChooser(Chooser):
                              wildcard=options.get('wildcard', wx.FileSelectorDefaultWildcardStr))
 
     def getResult(self, dialog):
-        return os.pathsep.join(dialog.GetPaths()) 
+        return os.pathsep.join(dialog.GetPaths())
 
 
 class FileSaver(Chooser):
@@ -107,7 +109,7 @@ class DirChooser(Chooser):
                             defaultPath=options.get('default_path', os.getcwd()))
 
 class MultiDirChooser(Chooser):
-    """ Retrieve an multiple directories from the system """
+    """ Retrieve multiple directories from the system """
     def getDialog(self):
         options = self.Parent._options
         return MDD.MultiDirDialog(self,
@@ -116,7 +118,18 @@ class MultiDirChooser(Chooser):
                                   defaultPath=options.get('default_path', os.getcwd()),
                                   agwStyle=MDD.DD_MULTIPLE | MDD.DD_DIR_MUST_EXIST)
     def getResult(self, dialog):
-        return os.pathsep.join(dialog.GetPaths())
+        paths = dialog.GetPaths()
+        # Remove volume labels from Windows paths
+        if 'nt' == os.name:
+            for i, path in enumerate(paths):
+                if path:
+                    purepath = pathlib.PurePath(path)
+                    parts = purepath.parts
+                    vol = parts[0]
+                    drives = re.match(r'.*\((?P<drive>\w:)\)', vol)
+                    paths[i] = os.sep.join((drives.group('drive'),) + parts[1:])
+
+        return os.pathsep.join(paths)
 
 
 class DateChooser(Chooser):
@@ -154,5 +167,3 @@ class ColourChooser(Chooser):
 
     def getDialog(self):
         return wx.ColourDialog(self)
-
-

--- a/gooey/tests/test_chooser_results.py
+++ b/gooey/tests/test_chooser_results.py
@@ -2,14 +2,15 @@ import argparse
 import os
 import unittest
 
-from unittest.mock import patch
 from gooey.gui.components.widgets.core import chooser
+
+class MockWxMDD:
+    def GetPaths(self):
+        pass
 
 class TestChooserResults(unittest.TestCase):
 
-    @patch('gooey.gui.components.widgets.core.chooser.MDD')
-    def test_multiDirChooserGetResult(self, mockWxMDD):
-
+    def test_multiDirChooserGetResult(self):
         expected_outputs = [
             (None, "", [""]),
 
@@ -23,7 +24,12 @@ class TestChooserResults(unittest.TestCase):
         ]
 
         for osname, expected, pathsoutput in expected_outputs:
-            if osname and osname == os.name:
-                mockWxMDD.GetPaths.return_value = pathsoutput
-                result = chooser.MultiDirChooser.getResult(None, mockWxMDD)
+            if not osname or osname == os.name:
+                chooser.MDD.MultiDirDialog = MockWxMDD
+                chooser.MDD.MultiDirDialog.GetPaths = lambda self : pathsoutput
+                result = chooser.MultiDirChooser.getResult(None, MockWxMDD())
+                print(result)
                 self.assertEqual(result, expected)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/gooey/tests/test_chooser_results.py
+++ b/gooey/tests/test_chooser_results.py
@@ -1,0 +1,29 @@
+import argparse
+import os
+import unittest
+
+from unittest.mock import patch
+from gooey.gui.components.widgets.core import chooser
+
+class TestChooserResults(unittest.TestCase):
+
+    @patch('gooey.gui.components.widgets.core.chooser.MDD')
+    def test_multiDirChooserGetResult(self, mockWxMDD):
+
+        expected_outputs = [
+            (None, "", [""]),
+
+            # Windows
+            ('nt', "C:", ["OS and System (C:)"]),
+            ('nt', "D:\\A Folder\\Yep Another One",
+             ["Other Stuff (D:)\\A Folder\\Yep Another One"]),
+            ('nt', "A:\\Wow Remember Floppy Drives;E:\\Righto Then",
+             ["Flipflop (A:)\\Wow Remember Floppy Drives",
+              "Elephants Only (E:)\\Righto Then"])
+        ]
+
+        for osname, expected, pathsoutput in expected_outputs:
+            if osname and osname == os.name:
+                mockWxMDD.GetPaths.return_value = pathsoutput
+                result = chooser.MultiDirChooser.getResult(None, mockWxMDD)
+                self.assertEqual(result, expected)


### PR DESCRIPTION
Fixes Issue #553.

If running on a Windows system, strips volume labels from directory path to leave only the drive letter. This path can then be ingested by other functionality that expects valid paths.

Does not touch functionality for non-Windows systems.

Compatible with Python 3.x and Python 2.7.