### PR TITLE
Update the wxPython version

### DIFF
--- a/gooey/__init__.py
+++ b/gooey/__init__.py
@@ -2,4 +2,4 @@ import os
 from gooey.python_bindings.gooey_decorator import Gooey
 from gooey.python_bindings.gooey_parser import GooeyParser
 from gooey.gui.util.freeze import localResourcePath as local_resource_path
-__version__ = '1.0.3.1'
+__version__ = '1.0.3.2'

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 with open('README.md') as readme:
     long_description = readme.read()
 
-version = '1.0.3.1'
+version = '1.0.3.2'
 
 deps = [
     'Pillow>=4.3.0',
@@ -15,7 +15,7 @@ deps = [
 ]
 
 if sys.version[0] == '3':
-    deps.append('wxpython==4.0.7')
+    deps.append('wxpython==4.0.7.post2')
 
 
 setup(


### PR DESCRIPTION
Submitting this pull request to the 1.0.3.1-hotfix branch because it seems most natural in this case.

Apparently the previous version of wxPython was causing an undocumented problem with “source code string cannot contain null bytes”. Steps to reproduce:

```
pex 'wxpython==4.0.7' --platform win_amd64-cp-38-cp38 -o example.pyz
```

Then (on Windows) `py example.pyz` and `import wx`.

If we replace `'wxpython==4.0.7'` with `'wxpython==4.0.7.post2'`, it starts to work (don’t know if it is actually related to PEX or not).