### PR TITLE
Add instructions for conda install

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ Table of Contents
 The easiest way to install Gooey is via `pip`
 
     pip install Gooey 
+	
+or `conda`
+
+    conda install Gooey -c conda-forge
 
 Alternatively, you can install Gooey by cloning the project to your local directory
 


### PR DESCRIPTION
Hi, I made Gooey available on conda forge ([recipe](https://github.com/conda-forge/gooey-feedstock))

I thought it would be useful to let your users know that it can be installed this way as well as with pip.

Let me know if you would like to be co-maintainer of the conda recipe. Right now it's just me. 