### PR TITLE
Silence Python 3.8 runtime warning

### DIFF
--- a/gooey/gui/processor.py
+++ b/gooey/gui/processor.py
@@ -48,12 +48,12 @@ class ProcessController(object):
         try:
             self._process = subprocess.Popen(
                 command.encode(sys.getfilesystemencoding()),
-                bufsize=1, stdout=subprocess.PIPE, stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE, stdin=subprocess.PIPE,
                 stderr=subprocess.STDOUT, shell=self.shell_execution, env=env)
         except:
             self._process = subprocess.Popen(
                 command,
-                bufsize=1, stdout=subprocess.PIPE, stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE, stdin=subprocess.PIPE,
                 stderr = subprocess.STDOUT, shell = self.shell_execution, env=env)
 
         t = Thread(target=self._forward_stdout, args=(self._process,))


### PR DESCRIPTION
This patch removes the buffer size paraemter in calls to `subprocess.Popen()` so that the default value is assumed. This silences this Python 3.8 runtime warning:

```
RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode, the default buffer size will be used```
