### PR TITLE
Behave like --ignore-gooey has been passed if the display is missing

### DIFF
--- a/gooey/python_bindings/gooey_decorator.py
+++ b/gooey/python_bindings/gooey_decorator.py
@@ -10,6 +10,7 @@ import json
 import os
 import sys
 from argparse import ArgumentParser
+import wx
 
 from gooey.gui.util.freeze import getResourcePath
 from gooey.util.functional import merge
@@ -97,8 +98,9 @@ def Gooey(f=None,
   def run_without_gooey(func):
     return lambda *args, **kwargs: func(*args, **kwargs)
 
-  if IGNORE_COMMAND in sys.argv:
-    sys.argv.remove(IGNORE_COMMAND)
+  if not wx.PyApp.IsDisplayAvailable() or IGNORE_COMMAND in sys.argv:
+    if IGNORE_COMMAND in sys.argv:
+      sys.argv.remove(IGNORE_COMMAND)
     if callable(f):
       return run_without_gooey(f)
     return run_without_gooey

--- a/gooey/python_bindings/gooey_decorator.py
+++ b/gooey/python_bindings/gooey_decorator.py
@@ -10,7 +10,12 @@ import json
 import os
 import sys
 from argparse import ArgumentParser
-import wx
+
+try:
+  import wx
+  wxFound = True
+except ModuleNotFoundError:
+  wxFound = False
 
 from gooey.gui.util.freeze import getResourcePath
 from gooey.util.functional import merge
@@ -98,7 +103,8 @@ def Gooey(f=None,
   def run_without_gooey(func):
     return lambda *args, **kwargs: func(*args, **kwargs)
 
-  if not wx.PyApp.IsDisplayAvailable() or IGNORE_COMMAND in sys.argv:
+  if not wxFound or not wx.PyApp.IsDisplayAvailable() or \
+     IGNORE_COMMAND in sys.argv:
     if IGNORE_COMMAND in sys.argv:
       sys.argv.remove(IGNORE_COMMAND)
     if callable(f):


### PR DESCRIPTION
This patch makes Gooey behave like --ignore-gooey has been passed if the display is missing. This allows Gooey applications to run unmodified on systems with no X display present.

Partially solves #296.
