### PR TITLE
Prevent crash when getting dynamic properties

### DIFF
--- a/gooey/gui/seeder.py
+++ b/gooey/gui/seeder.py
@@ -12,7 +12,7 @@ def fetchDynamicProperties(target, encoding):
     dynamically generated defaults with which to seed the UI
     """
     cmd = '{} {}'.format(target, 'gooey-seed-ui --ignore-gooey')
-    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
     if proc.returncode != 0:
         out, _ = proc.communicate()
         return json.loads(out.decode(encoding))


### PR DESCRIPTION
Since `args` is a string, the `Popen` constructor interprets "/usr/bin/python myscript.py" as a path to an executable instead of "/usr/bin/python" with argument "myscript.py".
Adding `shell=True` makes this behave as expected.

Fix #584