### PR TITLE
Fix show_stop_warning

### DIFF
--- a/gooey/gui/containers/application.py
+++ b/gooey/gui/containers/application.py
@@ -145,7 +145,7 @@ class GooeyApplication(wx.Frame):
     def onStopExecution(self):
         """Displays a scary message and then force-quits the executing
         client code if the user accepts"""
-        if self.buildSpec['show_stop_warning'] and modals.confirmForceStop():
+        if not self.buildSpec['show_stop_warning'] or modals.confirmForceStop():
             self.clientRunner.stop()
 
 


### PR DESCRIPTION
Previously, show_stop_warning=False would make the stop button do nothing
Now, if show_stop_warning=False the stop button stops the program without a warning dialog
