### PR TITLE
Fix warning when dynamically populating dropdown

### DIFF
--- a/gooey/gui/components/widgets/dropdown.py
+++ b/gooey/gui/components/widgets/dropdown.py
@@ -51,8 +51,9 @@ class Dropdown(TextContainer):
         try:
             yield
         finally:
-            current_at_index = self.widget.GetString(prevSelection)
-            if prevValue == current_at_index:
+            if prevSelection == -1:
+                self.widget.SetSelection(-1)
+            elif self.widget.GetString(prevSelection):
                 self.widget.SetSelection(prevSelection)
             else:
                 self.widget.SetSelection(0)


### PR DESCRIPTION
Previously, dynamically populating a dropdown can give this log message: `Gtk-CRITICAL **: 14:51:42.138: gtk_tree_model_iter_nth_child: assertion 'n >= 0' failed`
Now, the warning doesn't happen
