### PR TITLE
Copy widgets and their configuration from parent parsers. Resolves #608

### DIFF
--- a/gooey/python_bindings/gooey_parser.py
+++ b/gooey/python_bindings/gooey_parser.py
@@ -68,6 +68,11 @@ class GooeyParser(object):
         self.__dict__['parser'] = ArgumentParser(**kwargs)
         self.widgets = {}
         self.options = {}
+        if 'parents' in kwargs:
+            for parent in kwargs['parents']:
+                if isinstance(parent, self.__class__):
+                    self.widgets.update(parent.widgets)
+                    self.options.update(parent.options)
 
     @property
     def _mutually_exclusive_groups(self):

--- a/gooey/python_bindings/gooey_parser.py
+++ b/gooey/python_bindings/gooey_parser.py
@@ -93,8 +93,14 @@ class GooeyParser(object):
 
         action = self.parser.add_argument(*args, **kwargs)
         self.parser._actions[-1].metavar = metavar
-        self.widgets[self.parser._actions[-1].dest] = widget
-        self.options[self.parser._actions[-1].dest] = options
+
+        action_dest = self.parser._actions[-1].dest
+        if action_dest not in self.widgets or self.widgets[action_dest] is None:
+            self.widgets[action_dest] = widget
+
+        if action_dest not in self.options or self.options[action_dest] is None:
+            self.options[self.parser._actions[-1].dest] = options
+
         self._validate_constraints(
             self.parser._actions[-1],
             widget,

--- a/gooey/tests/test_parent_inheritance.py
+++ b/gooey/tests/test_parent_inheritance.py
@@ -1,0 +1,86 @@
+import argparse
+import unittest
+
+from gooey import GooeyParser
+
+
+class TestParentInheritance(unittest.TestCase):
+
+    def test_parent_arguments_exist_in_child(self):
+        """
+        Verifies that the parents parameter is honoured.
+        """
+        base_parser = GooeyParser(add_help=False)
+        base_parser.add_argument("a_file", widget="FileChooser")
+
+        parser = GooeyParser(parents=[base_parser])
+        parser.add_argument("b_file", widget="DirChooser")
+
+        found = 0
+        for action in parser._actions:
+            if action.dest == "a_file":
+                found += 1
+            elif action.dest == "b_file":
+                found += 1
+
+        self.assertEquals(2, found, "Did not find 2 expected arguments, found " + str(found))
+        self.assertEquals(parser.widgets["a_file"], "FileChooser")
+        self.assertEquals(parser.widgets["b_file"], "DirChooser")
+
+    def test_parent_arguments_are_not_overridden(self):
+        """
+        Verifies that the same named argument in a parent and child parser is accepted, and only the child
+        parser survives.
+        """
+        # Verify how vanilla argparse works
+        base_parser = argparse.ArgumentParser(add_help=False)
+        action1 = base_parser.add_argument("a_file", default="a")
+
+        parser = argparse.ArgumentParser(parents=[base_parser])
+        action2 = parser.add_argument("a_file", default="b")
+
+        self._verify_duplicate_parameters(action1, action2, parser)
+        # So a child can't override a parent - this isn't textbook inheritance
+
+        # Run the same test on GooeyParser
+        base_parser = GooeyParser(add_help=False)
+        action1 = base_parser.add_argument("a_file", widget="FileChooser", default="a")
+
+        parser = GooeyParser(parents=[base_parser])
+        action2 = parser.add_argument("a_file", widget="DirChooser", default="b")
+
+        self._verify_duplicate_parameters(action1, action2, parser)
+        self.assertEquals(parser.widgets["a_file"], "FileChooser")
+
+    def test_duplicates_on_same_parser_are_ignored(self):
+        """
+        Verify that adding duplicate named arguments works the same in argparse and Gooey.
+        Assuming the behaviour of the "default" parameter is a good match for the "widget" parameter.
+        """
+
+        # Verify how vanilla argparse works
+        parser = argparse.ArgumentParser()
+        action1 = parser.add_argument("a_file", default="a")
+        action2 = parser.add_argument("a_file", default="b")
+
+        self._verify_duplicate_parameters(action1, action2, parser)
+
+        # Run the same test on GooeyParser
+        parser = GooeyParser()
+        action1 = parser.add_argument("a_file", default="a", widget="FileChooser")
+        action2 = parser.add_argument("a_file", default="b", widget="DirChooser")
+
+        self._verify_duplicate_parameters(action1, action2, parser)
+        self.assertEquals(parser.widgets["a_file"], "FileChooser")
+
+    def _verify_duplicate_parameters(self, action1, action2, parser):
+        """
+        Verify two parameters named a_file exist and the default value is "a".
+        """
+        found = 0
+        for action in parser._actions:
+            if action.dest == "a_file":
+                found += 1
+        self.assertEquals(2, found, "Expected a both actions handling a_file but got " + str(found))
+        self.assertEquals(parser.get_default("a_file"), "a")
+        self.assertNotEqual(action1, action2)


### PR DESCRIPTION
Resolves issue #608 based on the sample code in issue.
I'm aware there's no automated tests, but I couldn't work out how to write one for this.