### PR TITLE
Ensure OnDropFiles function matches interface

### DIFF
--- a/gooey/gui/util/filedrop.py
+++ b/gooey/gui/util/filedrop.py
@@ -8,3 +8,4 @@ class FileDrop(wx.FileDropTarget):
   def OnDropFiles(self, x, y, filenames):
     for name in filenames:
       self.window.WriteText(name)
+    return True


### PR DESCRIPTION
Fixes the following error printed to the console after dropping a file onto a text box: 
```
TypeError: invalid result from FileDrop.OnDropFiles(), a 'bool' is expected not 'NoneType'
```

