### PR TITLE
Fix #592 - No in Close does not freeze Gooey now

### DIFF
--- a/gooey/gui/containers/application.py
+++ b/gooey/gui/containers/application.py
@@ -145,9 +145,11 @@ class GooeyApplication(wx.Frame):
     def onStopExecution(self):
         """Displays a scary message and then force-quits the executing
         client code if the user accepts"""
+        exit_flag = False
         if not self.buildSpec['show_stop_warning'] or modals.confirmForceStop():
+            exit_flag = True
             self.clientRunner.stop()
-
+        return exit_flag
 
     def fetchExternalUpdates(self):
         """
@@ -176,10 +178,13 @@ class GooeyApplication(wx.Frame):
         # when the exit button is clicked to ensure everything is cleaned
         # up correctly.
         if self.clientRunner.running():
-            self.onStopExecution()
-        self.Destroy()
-        sys.exit()
-
+            if self.onStopExecution():
+                self.Destroy()
+                sys.exit()
+        else:
+            self.Destroy()
+            sys.exit()
+            
 
     def layoutComponent(self):
         sizer = wx.BoxSizer(wx.VERTICAL)


### PR DESCRIPTION
Selecting 'No' in Close Modal caused Gooey to hang.
This was because of control reaching self.Destroy() despite the 'No' selection.
This is fixed simply by adding a boolean flag.