### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
 Hello There, Future Issue Creator! 
 
->README: Are you suddenly seeing errors related to Alignmnet flags when starting Gooey? Upgrade your gooey installation to the latest version (`pip install -U gooey`) to resolve the errors! See [this issue](https://github.com/chriskiehl/Gooey/issues/549) for additional information. 
+>README: Are you suddenly seeing errors related to Alignment flags when starting Gooey? Upgrade your gooey installation to the latest version (`pip install -U gooey`) to resolve the errors! See [this issue](https://github.com/chriskiehl/Gooey/issues/549) for additional information. 
 
 Found a bug? Just a friendly heads up, _debugging it requires information from you!_ Make sure the template below is filled out in its entirety. 
 

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Gooey is international ready and easily ported to your host language. Languages 
 
 All program text is stored externally in `json` files. So adding new language support is as easy as pasting a few key/value pairs in the `gooey/languages/` directory. 
 
-Thanks to some awesome [contributers](https://github.com/chriskiehl/Gooey/graphs/contributors), Gooey currently comes pre-stocked with over 18 different translations! 
+Thanks to some awesome [contributors](https://github.com/chriskiehl/Gooey/graphs/contributors), Gooey currently comes pre-stocked with over 18 different translations! 
 
 Want to add another one? Submit a [pull request!](https://github.com/chriskiehl/Gooey/compare)
 
@@ -712,7 +712,7 @@ Images are discovered by Gooey based on their _filenames_. So, for example, in o
 
 ## Packaging
 
-Thanks to some [awesome contributers](https://github.com/chriskiehl/Gooey/issues/58), packaging Gooey as an executable is super easy. 
+Thanks to some [awesome contributors](https://github.com/chriskiehl/Gooey/issues/58), packaging Gooey as an executable is super easy. 
 
 The tl;dr [pyinstaller](https://github.com/pyinstaller/pyinstaller) version is to drop this [build.spec](https://github.com/chriskiehl/Gooey/files/29568/build.spec.txt) into the root directory of your application. Edit its contents so that the `application` and `name` are relevant to your project, then execute `pyinstaller build.spec` to bundle your app into a ready-to-go executable. 
 

--- a/docs/Gooey-Options.md
+++ b/docs/Gooey-Options.md
@@ -113,7 +113,7 @@ parser.add_mutually_exclusive_group(gooey_options={
 Argument Groups take a number of `gooey_options` to help control layout. 
 
 ```python
-parser.add_argument_group('MyGroup', desription='my cool group', gooey_options={
+parser.add_argument_group('MyGroup', description='my cool group', gooey_options={
     'show_border': bool,
     'show_underline': bool,
     'label_color': '#FF9900',

--- a/gooey/gui/components/widgets/bases.py
+++ b/gooey/gui/components/widgets/bases.py
@@ -33,7 +33,7 @@ class BaseWidget(wx.Panel):
     def dispatchChange(self, value, **kwargs):
         raise NotImplementedError
 
-    def formatOutput(self, metatdata, value):
+    def formatOutput(self, metadata, value):
         raise NotImplementedError
 
 
@@ -155,7 +155,7 @@ class TextContainer(BaseWidget):
     def setOptions(self, values):
         return None
 
-    def receiveChange(self, metatdata, value):
+    def receiveChange(self, metadata, value):
         raise NotImplementedError
 
     def dispatchChange(self, value, **kwargs):
@@ -176,5 +176,5 @@ class BaseChooser(TextContainer):
     def getWidgetValue(self):
         return self.widget.getValue()
 
-    def formatOutput(self, metatdata, value):
-        return formatters.general(metatdata, value)
+    def formatOutput(self, metadata, value):
+        return formatters.general(metadata, value)

--- a/gooey/gui/components/widgets/checkbox.py
+++ b/gooey/gui/components/widgets/checkbox.py
@@ -46,8 +46,8 @@ class CheckBox(TextContainer):
         return self.widget.GetValue()
 
 
-    def formatOutput(self, metatdata, value):
-        return formatters.checkbox(metatdata, value)
+    def formatOutput(self, metadata, value):
+        return formatters.checkbox(metadata, value)
 
 
     def hideInput(self):

--- a/gooey/gui/components/widgets/choosers.py
+++ b/gooey/gui/components/widgets/choosers.py
@@ -24,8 +24,8 @@ class MultiFileChooser(BaseChooser):
     # todo: allow wildcard from argparse
     widget_class = core.MultiFileChooser
 
-    def formatOutput(self, metatdata, value):
-        return formatters.multiFileChooser(metatdata, value)
+    def formatOutput(self, metadata, value):
+        return formatters.multiFileChooser(metadata, value)
 
 
 class FileSaver(BaseChooser):

--- a/gooey/gui/components/widgets/dialogs/base_dialog.py
+++ b/gooey/gui/components/widgets/dialogs/base_dialog.py
@@ -47,10 +47,8 @@ class BaseDialog(wx.Dialog):
     """
       Return the value chosen in the picker.
       The method is called GetPath() instead of getPath() to emulate the WX Pickers API.
-      This allows the Chooser class to work same way with native WX dialogs or childs of BaseDialog.
+      This allows the Chooser class to work same way with native WX dialogs or children
+          of BaseDialog.
     """
 
     return self.pickerGetter(self.picker)
-
-
-

--- a/gooey/gui/components/widgets/textarea.py
+++ b/gooey/gui/components/widgets/textarea.py
@@ -32,7 +32,7 @@ class Textarea(TextContainer):
         self.widget.AppendText(str(value))
         self.widget.SetInsertionPoint(0)
 
-    def formatOutput(self, metatdata, value):
-        return formatters.general(metatdata, value)
+    def formatOutput(self, metadata, value):
+        return formatters.general(metadata, value)
 
 

--- a/gooey/gui/components/widgets/textfield.py
+++ b/gooey/gui/components/widgets/textfield.py
@@ -15,6 +15,6 @@ class TextField(TextContainer):
     def setValue(self, value):
         self.widget.setValue(str(value))
 
-    def formatOutput(self, metatdata, value):
-        return formatters.general(metatdata, value)
+    def formatOutput(self, metadata, value):
+        return formatters.general(metadata, value)
 

--- a/gooey/gui/formatters.py
+++ b/gooey/gui/formatters.py
@@ -38,7 +38,7 @@ def commandField(metadata, value):
         return value or None
 
 
-def counter(metatdata, value):
+def counter(metadata, value):
     '''
     Returns
       str(option_string * DropDown Value)
@@ -47,7 +47,7 @@ def counter(metatdata, value):
     '''
     if not str(value).isdigit():
         return None
-    command = str(metatdata['commands'][0]).strip()
+    command = str(metadata['commands'][0]).strip()
     return ' '.join(itertools.repeat(command, int(value)))
 
 

--- a/gooey/python_bindings/argparse_to_json.py
+++ b/gooey/python_bindings/argparse_to_json.py
@@ -546,7 +546,7 @@ def clean_default(default):
         return default
     except TypeError as e:
         # see: Issue #377
-        # if is ins't json serializable (i.e. primitive data) there's nothing
+        # if is isn't json serializable (i.e. primitive data) there's nothing
         # useful for Gooey to do with it (since Gooey deals in primitive data
         # types). So the correct behavior is dropping them. This affects ONLY
         # gooey, not the client code.

--- a/gooey/tests/test_formatters.py
+++ b/gooey/tests/test_formatters.py
@@ -47,7 +47,7 @@ class TestFormatters(unittest.TestCase):
     def test_multifilechooser_formatter(self):
         """
         Should return files (quoted), separated by spaces if there is more
-        than one, preceeded by optional command if the argument is optional.
+        than one, preceded by optional command if the argument is optional.
 
         Assumes the argument has been created with some form of nargs, which
         only makes sense for possibly choosing multiple values.


### PR DESCRIPTION
Hello there!

[codespell](https://github.com/codespell-project/codespell) --ignore-words-list="datas" --quiet-level=2 --skip="*.json,*.spec"
* `datas` is not a word in English but I hesitated to fix this typo which appears in two files.

Make sure you've followed the [Contributing](https://github.com/chriskiehl/Gooey/blob/master/CONTRIBUTING.md) guidelines before finalizing your pull request. 

TL;DR: 

 - [x] You're opening this PR against the current [release branch](https://github.com/chriskiehl/Gooey/blob/master/CONTRIBUTING.md#development-overview)
 - [x] Works on both Python 2.7 & Python 3.x
 - [x] Commits have been squashed and includes the relevant issue number
 - [x] Pull request description contains link to relevant issue or detailed notes on changes
  - [x] This **must** include example code demonstrating your feature or the bug being fixed
 - [x] All existing tests pass 
 - [x] Your bug fix / feature has associated test coverage (in #619)
 - [x] README.md is updated (if relevant)
