### PR TITLE
Use program_name instead of script file name in macOS menu

### DIFF
--- a/gooey/gui/application.py
+++ b/gooey/gui/application.py
@@ -24,6 +24,8 @@ def run(build_spec):
 
 def build_app(build_spec):
   app = wx.App(False)
+  # use actual program name instead of script file name in macOS menu
+  app.SetAppDisplayName(build_spec['program_name'])
 
   i18n.load(build_spec['language_dir'], build_spec['language'], build_spec['encoding'])
   imagesPaths = image_repository.loadImages(build_spec['image_dir'])


### PR DESCRIPTION
Cosmetic fix of default menu on macOS

Before:
<img width="246" alt="gooey-before" src="https://user-images.githubusercontent.com/441968/92927948-51711c00-f436-11ea-95ba-23646234b077.png">

After:
<img width="216" alt="gooey-after" src="https://user-images.githubusercontent.com/441968/92927960-5635d000-f436-11ea-94a5-861068204105.png">


 - [x] You're opening this PR against the current [release branch](https://github.com/chriskiehl/Gooey/blob/master/CONTRIBUTING.md#development-overview)
 - [x] Works on both Python 2.7 & Python 3.x
 - [x] Commits have been squashed and includes the relevant issue number
 - [x] Pull request description contains link to relevant issue or detailed notes on changes
 - [x] This **must** include example code demonstrating your feature or the bug being fixed
 - [x] All existing tests pass 
 - [n/a] Your bug fix / feature has associated test coverage 
 - [n/a] README.md is updated (if relevant)
