### PR TITLE
Resolves #653 - a missing translation step for tabbed group titles.

### DIFF
--- a/gooey/gui/components/config.py
+++ b/gooey/gui/components/config.py
@@ -211,7 +211,7 @@ class TabbedConfigPage(ConfigPage):
             self.makeGroup(panel, sizer, group, 0, wx.EXPAND)
             panel.SetSizer(sizer)
             panel.Layout()
-            self.notebook.AddPage(panel, group['name'])
+            self.notebook.AddPage(panel, self.getName(group))
             self.notebook.Layout()
 
 


### PR DESCRIPTION
Visually verified as fixed, now shows: 
![image](https://user-images.githubusercontent.com/6201399/99542684-3ed11100-29aa-11eb-93f2-bbf8e87b9fb8.png)
and bespoke group titles render OK still.
