### PR TITLE
fixed a minor bug

### DIFF
--- a/gooey/gui/components/options/options.py
+++ b/gooey/gui/components/options/options.py
@@ -7,7 +7,7 @@ def _include_layout_docs(f):
     Combines the layout_options docsstring with the
     wrapped function's doc string.
     """
-    f.__doc__ = (f.__doc__ or '') + LayoutOptions.__doc__
+    f.__doc__ = (f.__doc__ or '') + (LayoutOptions.__doc__ or '')
     return f
 
 


### PR DESCRIPTION
Found a minor syntactical bug when I was packaging with PyInstaller on Windows and Mac. 

On Windows, the build process fails immediately.
On Mac, the build succeeds, but when the program is launched it shows up and kills the app.
The error is the same on Windows and Mac.

```
Traceback (most recent call last):
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "PyInstaller/loader/pyimod03_importers.py", line 531, in exec_module
  File "gooey/__init__.py", line 7, in <module>
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "PyInstaller/loader/pyimod03_importers.py", line 531, in exec_module
  File "gooey/gui/components/options/options.py", line 90, in <module>
  File "gooey/gui/components/options/options.py", line 10, in _include_layout_docs
TypeError: can only concatenate str (not "NoneType") to str
```