### PR TITLE
Determine directories before current working directory may change.

### DIFF
--- a/gooey/python_bindings/gooey_decorator.py
+++ b/gooey/python_bindings/gooey_decorator.py
@@ -86,6 +86,19 @@ def Gooey(f=None,
   Decorator for client code's main function.
   Serializes argparse data to JSON for use with the Gooey front end
   '''
+  # Note: current working directory may change
+  #
+  # Determine these directories before the current directory may change due to
+  # widgets like Filechooser or DirChooser.
+  # So now you can enter this command line:
+  #
+  # $ python cli.py
+  #
+  # instead of:
+  #
+  # $ python /absolute/path/to/cli.py
+  exec_dir = os.path.dirname(os.path.abspath(sys.argv[0]))
+  config_path = os.path.join(os.path.abspath(os.path.dirname(sys.argv[0])), 'gooey_config.json')
 
   params = merge(locals(), locals()['kwargs'])
 
@@ -98,7 +111,8 @@ def Gooey(f=None,
       build_spec = None
       if load_build_config:
         try:
-          exec_dir = os.path.dirname(sys.argv[0])
+          # See note above.
+          # exec_dir = os.path.dirname(sys.argv[0])
           open_path = os.path.join(exec_dir,load_build_config)
           build_spec = json.load(open(open_path, "r"))
         except Exception as e:
@@ -116,7 +130,8 @@ def Gooey(f=None,
           **params)
 
       if dump_build_config:
-        config_path = os.path.join(os.path.dirname(sys.argv[0]), 'gooey_config.json')
+        # See note above.
+        # config_path = os.path.join(os.path.dirname(sys.argv[0]), 'gooey_config.json')
         print('Writing Build Config to: {}'.format(config_path))
         with open(config_path, 'w') as f:
           f.write(json.dumps(build_spec, indent=2))


### PR DESCRIPTION
Hello there! 

Make sure you've followed the [Contributing](https://github.com/chriskiehl/Gooey/blob/master/CONTRIBUTING.md) guidelines before finalizing your pull request. 

TL;DR: 

 - [X] You're opening this PR against the current [release branch](https://github.com/chriskiehl/Gooey/blob/master/CONTRIBUTING.md#development-overview)
 - [X] Works on both Python 2.7 & Python 3.x
 - [X] Commits have been squashed and includes the relevant issue number
 - [X] Pull request description contains link to relevant issue or detailed notes on changes
  - [X] This **must** include example code demonstrating your feature or the bug being fixed
 - [X] All existing tests pass 
 - [X] Your bug fix / feature has associated test coverage 
 - [X] README.md is updated (if relevant)

Issue: [The CLI can not find the (relative) script since it seems that the working directory has changed after using widgets FileChooser or DirChooser. ](https://github.com/chriskiehl/Gooey/issues/695)

Code:
```
  # Note: current working directory may change
  #
  # Determine these directories before the current directory may change due to
  # widgets like Filechooser or DirChooser.
  # So now you can enter this command line:
  #
  # $ python cli.py
  #
  # instead of:
  #
  # $ python /absolute/path/to/cli.py
  exec_dir = os.path.dirname(os.path.abspath(sys.argv[0]))
  config_path = os.path.join(os.path.abspath(os.path.dirname(sys.argv[0])), 'gooey_config.json')

  params = merge(locals(), locals()['kwargs'])

  def build(payload):
    def run_gooey(self, args=None, namespace=None):
      # This import is delayed so it is not in the --ignore-gooey codepath.
      from gooey.gui import application
      source_path = sys.argv[0]

      build_spec = None
      if load_build_config:
        try:
          # See note above.
          # exec_dir = os.path.dirname(sys.argv[0])
          open_path = os.path.join(exec_dir,load_build_config)
          build_spec = json.load(open(open_path, "r"))
        except Exception as e:
          print('Exception loading Build Config from {0}: {1}'.format(load_build_config, e))
          sys.exit(1)

      if not build_spec:
        if use_cmd_args:
          cmd_args.parse_cmd_args(self, args)

        build_spec = config_generator.create_from_parser(
          self,
          source_path,
          payload_name=payload.__name__,
          **params)

      if dump_build_config:
        # See note above.
        # config_path = os.path.join(os.path.dirname(sys.argv[0]), 'gooey_config.json')
        print('Writing Build Config to: {}'.format(config_path))
        with open(config_path, 'w') as f:
          f.write(json.dumps(build_spec, indent=2))
      application.run(build_spec)

    def inner2(*args, **kwargs):
      ArgumentParser.original_parse_args = ArgumentParser.parse_args
      ArgumentParser.parse_args = run_gooey
      return payload(*args, **kwargs)

    inner2.__name__ = payload.__name__
    return inner2
```
