### PR TITLE
Run easy install script if parent script is a windows executable

### DIFF
--- a/gooey/python_bindings/config_generator.py
+++ b/gooey/python_bindings/config_generator.py
@@ -27,6 +27,41 @@ default_layout = {
 def create_from_parser(parser, source_path, **kwargs):
 
   run_cmd = kwargs.get('target')
+  if os.path.exists('{}.exe'.format(source_path)):
+    # This is installed as a windows executable
+
+    script_path = '{}-script.py'.format(source_path)
+    if not os.path.exists(script_path):
+      # If easy_install script does not exist, create it
+      executable_name = os.path.split(source_path)[-1]
+      easy_install_script = [
+        '#!{}'.format(sys.executable),
+        'import re',
+        'import sys',
+        '__requires__ = "{}"'.format(executable_name),
+        'try:',
+        '    from importlib.metadata import distribution',
+        'except ImportError:',
+        '    try:',
+        '        from importlib_metadata import distribution',
+        '    except ImportError:',
+        '        from pkg_resources import load_entry_point',
+        'def importlib_load_entry_point(spec, group, name):',
+        '    dist_name, _, _ = spec.partition("==")',
+        '    matches = (',
+        '        entry_point',
+        '        for entry_point in distribution(dist_name).entry_points',
+        '        if entry_point.group == group and entry_point.name == name',
+        '    )',
+        '    return next(matches).load()',
+        'globals().setdefault("load_entry_point", importlib_load_entry_point)',
+        'if __name__ == "__main__":',
+        '    sys.argv[0] = re.sub(r"(-script\.pyw?|\.exe)?$", "", sys.argv[0])',
+        '    sys.exit(load_entry_point("{}", "console_scripts", "{}")())'.format(executable_name, executable_name)
+      ]
+      with open(script_path, 'w') as fp:
+        fp.writelines('\n'.join(easy_install_script))
+    source_path = script_path
   if run_cmd is None:
     if hasattr(sys, 'frozen'):
       run_cmd = quote(source_path)
@@ -125,17 +160,17 @@ def create_from_parser(parser, source_path, **kwargs):
 
 def get_font_weight(kwargs):
     error_msg = textwrap.dedent('''
-    Unknown font weight {}. 
-    
-    The available weights can be found in the `constants` module. 
+    Unknown font weight {}.
+
+    The available weights can be found in the `constants` module.
     They're prefixed with "FONTWEIGHT" (e.g. `FONTWEIGHT_BOLD`)
-    
-    example code:    
-    
+
+    example code:
+
     ```
     from gooey import constants
     @Gooey(terminal_font_weight=constants.FONTWEIGHT_NORMAL)
-    ```   
+    ```
     ''')
     weights = {
         constants.FONTWEIGHT_THIN,


### PR DESCRIPTION
# Checklist
 - [x] You're opening this PR against the current [release branch](https://github.com/chriskiehl/Gooey/blob/master/CONTRIBUTING.md#development-overview)
 - [ ] Works on both Python 2.7 & Python 3.x
 - [x] Commits have been squashed and includes the relevant issue number
 - [x] Pull request description contains link to relevant issue or detailed notes on changes
  - [x] This **must** include example code demonstrating your feature or the bug being fixed
 - [x] All existing tests pass 
 - [ ] Your bug fix / feature has associated test coverage 
 - [ ] ~~README.md is updated (if relevant)~~

# Python 2.7 note
Python 2.7 is EoL.  I did try to check if it works on 2.7 and use old-school `.format` but when I created a 2.7 environment and attempted to install Gooey I got the following error:
```ERROR: Could not find a version that satisfies the requirement Pillow>=4.3.0```

So currently I'm not positive Gooey's dependencies are available from 2.7

As such, I'm not going to test python 2.7 and I do apologize.  If this cannot be merged b/c of that, so be it and thank you for your time!

# Issue notes
Fixes related issues https://github.com/chriskiehl/Gooey/issues/455 and https://github.com/chriskiehl/Gooey/issues/649

**Core issue**: for windows install packaged code that is pip installed, there will be an executable .exe file.  When Gooey is run, it cannot find that exe file.  If we instead point to the easy-install file with the suffix `-script.py` then Gooey runs as desired.  Also, depending on install method, there is or is not an easy-install script file to correctly execute the executable.

This PR checks if the script being executed is actually an .exe file.  
If it is an .exe file, then it will check if there is an easy-install script.  
If there is no easy-install script, it will create one in the Scripts directory

It will then run the easy-install script in place of the original target, which will now correctly reference the .exe file.
# System:
```
Windows 10
python 3.6
```

# Manual testing
I have a pip installable package decorated with `@Gooey` at the function which has my Arg parser

1. Test editable install
```
pip uninstall my_package
cd my_package
pip install -e .
```
run your package and confirm it works

2. Test normal install
```
pip uninstall my_package
cd my_package
pip install .
```
run your package and confirm it works

```
pip uninstall my_package
```
confirm file that was created (`my_package-script.py`) is cleaned up by uninstall


