### PR TITLE
Issue 756 nargs initial values

### DIFF
--- a/gooey/tests/test_argparse_to_json.py
+++ b/gooey/tests/test_argparse_to_json.py
@@ -184,6 +184,8 @@ class TestArgparse(unittest.TestCase):
 
         Using nargs and a `default` value with a list causes the literal list string
         to be put into the UI.
+
+        Also tests initial_value - see issue #756.
         """
         testcases = [
             {'nargs': '+', 'default': ['a b', 'c'], 'gooey_default': '"a b" "c"', 'w': 'TextField'},
@@ -214,6 +216,13 @@ class TestArgparse(unittest.TestCase):
                 parser.add_argument('--foo', nargs=case['nargs'], default=case['default'])
                 action = parser._actions[-1]
                 result = argparse_to_json.handle_initial_values(action, case['w'], action.default)
+                self.assertEqual(result, case['gooey_default'])
+
+                gooey_parser = GooeyParser(prog='test_program')
+                options = {'initial_value': case['default']}
+                gooey_parser.add_argument('--foo', nargs=case['nargs'], gooey_options=options)
+                action = gooey_parser._actions[-1]
+                result = argparse_to_json.handle_initial_values(action, case['w'], case['default'])
                 self.assertEqual(result, case['gooey_default'])
 
     def test_nargs(self):


### PR DESCRIPTION
Closes #756. I've updated an existing test for default values to also check that initial values are handled correctly. The code example in the issue now works as expected.

 - [x] You're opening this PR against the current [release branch](https://github.com/chriskiehl/Gooey/blob/master/CONTRIBUTING.md#development-overview)
 - [x] Works on both Python 2.7 & Python 3.x
 - [x] Commits have been squashed and includes the relevant issue number
 - [x] Pull request description contains link to relevant issue or detailed notes on changes
  - [x] This **must** include example code demonstrating your feature or the bug being fixed
 - [x] All existing tests pass 
 - [x] Your bug fix / feature has associated test coverage 
 - [x] README.md is updated (if relevant)