### PR TITLE
Only include non default arguments when invoking process

### DIFF
--- a/gooey/gui/components/config.py
+++ b/gooey/gui/components/config.py
@@ -46,7 +46,7 @@ class ConfigPage(ScrolledPanel):
 
     def getOptionalArgs(self):
         return [widget.getValue()['cmd'] for widget in self.reifiedWidgets
-                if widget.info['cli_type'] != 'positional']
+                if widget.info['cli_type'] != 'positional' and str(widget.getValue()['rawValue']) != str(widget.info['data']['default'])]
 
 
     def isValid(self):

--- a/gooey/python_bindings/cmd_args.py
+++ b/gooey/python_bindings/cmd_args.py
@@ -52,8 +52,12 @@ def parse_cmd_args(self, args=None):
       else:
         dest = getattr(action, 'dest', None)
         if dest:
-          cmd_arg = getattr(cmd_args, dest, None)
-          if cmd_arg:
+          cmd_arg = getattr(cmd_args, dest, None)        
+          if cmd_arg and dest in item.options and 'initial_value' not in (item.options[dest] or {}):
+            if item.options[dest] is None:
+              item.options[dest] = {}
+            item.options[dest]['initial_value'] = cmd_arg
+          else:
             action.default = cmd_arg
 
   def restore_original_configuration(item):


### PR DESCRIPTION
This is a WIP pull request; it does NOT pass unit tests and would need a bit more work to be mergeable. The main question right now is if its a feature that would be mergeable in general. 

The basic issue I have is that Gooey passes even default options to the process; and so replicating a minimal command line equivalent is hard. 

Since this change would change current behavior, I'm thinking it'd need to be gated behind a default off buildspec argument. If that is something that you'd merge in, I'll add that option in and propagate it through.