### PR TITLE
Added support for additional form of terminal coloring

### DIFF
--- a/gooey/gui/components/widgets/richtextconsole.py
+++ b/gooey/gui/components/widgets/richtextconsole.py
@@ -57,10 +57,12 @@ class RichTextConsole(wx.richtext.RichTextCtrl):
         # Actions for coloring text
         for index, hex in enumerate(kColorList):
             escSeq = '{}{}{}'.format(colored.fore.ESC, index, colored.fore.END)
+            escSeqShort = '\x1b[0;{}{}'.format(index, colored.fore.END)
             wxcolor = wx.Colour(int(hex[1:3],16), int(hex[3:5],16), int(hex[5:],16), alpha=wx.ALPHA_OPAQUE)
             # NB : we use a default parameter to force the evaluation of the binding
-            self.actionsMap[escSeq] = lambda bindedColor=wxcolor: self.BeginTextColour(bindedColor)
-            
+            self.actionsMap[escSeqShort] = self.actionsMap[escSeq] = \
+                lambda bindedColor=wxcolor: self.BeginTextColour(bindedColor)
+
         self.Bind(wx.EVT_MOUSEWHEEL, self.onMouseWheel)
 
 


### PR DESCRIPTION
This adds support for the common `[0;<color idx>m` escape codes. colored doesn't use these; but many other shell programs do. The current behavior removes the escape characters correctly but doesn't colorize the output.

If this runs afoul of the current refactor just let it wait and then I can rebase then retest this portion of code.