### PR TITLE
Conquer the land of arguing snakes

### DIFF
--- a/gooey/__main__.py
+++ b/gooey/__main__.py
@@ -1,12 +1,13 @@
-# '''
-# Delegates arguments to the main Gooey runner
-#
-# For use when run directly from command line with the -m (module) flag:
-#
-#   e.g. $ python -m gooey
-#
-# '''
-#
-# from gooey import application
-#
-# application.main()
+'''
+Delegates arguments to the main Gooey runner.
+
+For use when run directly from command line with the -m (module) flag:
+
+  e.g. $ python -m gooey
+
+'''
+
+from gooey.cli import main
+
+if __name__ == '__main__':
+    main()

--- a/gooey/cli.py
+++ b/gooey/cli.py
@@ -38,4 +38,4 @@ def main(args=None):
     sys.argv = [prog, *args[1:]]
     module = import_module(module_path)
     function = getattr(module, function_name)
-    return Gooey(use_cmd_args=True)(function)
+    return Gooey(function, use_cmd_args=True)()

--- a/gooey/cli.py
+++ b/gooey/cli.py
@@ -28,4 +28,4 @@ def main(args=None):
     sys.argv = [prog, *args[1:]]
     module = import_module(module_path)
     function = getattr(module, function_name)
-    return Gooey(function)
+    return Gooey(use_cmd_args=True)(function)

--- a/gooey/cli.py
+++ b/gooey/cli.py
@@ -2,7 +2,10 @@
 
 import sys
 from importlib import import_module
-from importlib.metadata import entry_points
+try:
+    from importlib.metadata import entry_points
+except ImportError:
+    from importlib_metadata import entry_points
 
 from gooey import Gooey
 
@@ -26,6 +29,9 @@ def main(args=None):
         # the path to a function was passed
         module_path, function_name = args[0].split(':')
         prog = module_path.split('.', 1)[0]
+    else:
+        print('usage: gooey [SCRIPT | MODULE:FUNCTION] [-- SCRIPT_ARGS...]', file=sys.stderr)
+        sys.exit(1)
     if len(args) > 1:
         if args[1] == '--':
             del args[1]

--- a/gooey/cli.py
+++ b/gooey/cli.py
@@ -1,0 +1,18 @@
+'''The command line interface.'''
+
+import sys
+from importlib import import_module
+
+from gooey import Gooey
+
+
+def main(args=None):
+    args = args or sys.argv[1:]
+    module_path, function_name = args[0].split(':')
+    if len(args) > 1:
+        if args[1] == '--':
+            del args[1]
+    sys.argv = ['gooey', *args[1:]]
+    module = import_module(module_path)
+    function = getattr(module, function_name)
+    return Gooey(function)()

--- a/gooey/cli.py
+++ b/gooey/cli.py
@@ -2,17 +2,30 @@
 
 import sys
 from importlib import import_module
+from importlib.metadata import entry_points
 
 from gooey import Gooey
 
 
 def main(args=None):
     args = args or sys.argv[1:]
-    module_path, function_name = args[0].split(':')
+    if not args:
+        script_name = "gooey"
+    else:
+        script_name = args[0]
+    scripts = {script.name: script for script in entry_points().get('console_scripts')}
+    if script_name in scripts:
+        script = scripts[script_name]
+        module_path = script.module
+        function_name = script.attr
+        prog = script_name
+    elif ':' in script_name:
+        module_path, function_name = args[0].split(':')
+        prog = module_path.split('.', 1)[0]
     if len(args) > 1:
         if args[1] == '--':
             del args[1]
-    sys.argv = ['gooey', *args[1:]]
+    sys.argv = [prog, *args[1:]]
     module = import_module(module_path)
     function = getattr(module, function_name)
-    return Gooey(function)()
+    return Gooey(function)

--- a/gooey/cli.py
+++ b/gooey/cli.py
@@ -10,16 +10,20 @@ from gooey import Gooey
 def main(args=None):
     args = args or sys.argv[1:]
     if not args:
+        # without args we assume we want to run gooey on gooey itself
+        # TODO: rewrite using argparse
         script_name = "gooey"
     else:
         script_name = args[0]
     scripts = {script.name: script for script in entry_points().get('console_scripts')}
     if script_name in scripts:
+        # a valid script was passed
         script = scripts[script_name]
         module_path = script.module
         function_name = script.attr
         prog = script_name
     elif ':' in script_name:
+        # the path to a function was passed
         module_path, function_name = args[0].split(':')
         prog = module_path.split('.', 1)[0]
     if len(args) > 1:

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ deps = [
     're-wx>=0.0.9',
     'typing-extensions==3.10.0.2',
     'wxpython>=4.1.0',
-    'dataclasses>=0.8; python_version < "3.7"'
+    'dataclasses>=0.8; python_version < "3.7"',
     'importlib-metadata; python_version < "3.8"',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ deps = [
     'typing-extensions==3.10.0.2',
     'wxpython>=4.1.0',
     'dataclasses>=0.8; python_version < "3.7"'
+    'importlib-metadata; python_version < "3.8"',
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     install_requires=deps,
     include_package_data=True,
     dependency_links = ["http://www.wxpython.org/download.php"],
+    entry_points={'console_scripts': ['gooey = gooey.cli:main']},
     classifiers = [
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',


### PR DESCRIPTION
Implements #519 (draft)

Original PR title is "Add CLI to run any Python program based on argparse", feel free to put it back :joy: 

 - [x] You're opening this PR against the current [release branch](https://github.com/chriskiehl/Gooey/blob/master/CONTRIBUTING.md#development-overview)
 - [x] Works on both Python 2.7 & Python 3.x
 - [x] Commits have been squashed and includes the relevant issue number
 - [x] Pull request description contains link to relevant issue or detailed notes on changes
  - [x] This **must** include example code demonstrating your feature or the bug being fixed
 - [ ] All existing tests pass: they don't, I have errors like this:
     - `AttributeError: module 'wx' has no attribute 'TaskBarIcon'`
 - [ ] Your bug fix / feature has associated test coverage 
 - [ ] README.md is updated (if relevant)

---

So, this PR basically adds a CLI to Gooey, allowing users to **run any argparse-based Python program from the command line**. I personally think it's awesome. You still need to pass the module path and function name as `module.path:function_name` because I couldn't find a way yet to infer it from the console script name. Indeed, the console script name can be different than the library name. We could try and read the script itself, as it's quite standardized, to find the actual function to import, but it's not bullet-proof either: on Windows such scripts are written as .exe, and I don't think it's easy to read. Maybe there's a way with importlib.metadata.

I went with a simple `sys.argv`, because using argparse in the CLI felt a bit too... recursive? But after all, why not, this would allow to run Gooey on itself, which is kind of awesome too. Imagine typing just "gooey" in the terminal: it opens a simple window with a single input, and a list of detected scripts/libraries/entrypoints (not sure how to do that yet). You type one, hit enter, and a new window pops up, this time with the selected program options and stuff.