### PR TITLE
fix installation 1.2.0-alpha on python > 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ deps = [
     're-wx>=0.0.9',
     'typing-extensions==3.10.0.2',
     'wxpython>=4.1.0',
-    'dataclasses>=0.8',
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ deps = [
     're-wx>=0.0.9',
     'typing-extensions==3.10.0.2',
     'wxpython>=4.1.0',
+    "dataclasses>=0.8;python_version<'3.7'",
 ]
 
 setup(


### PR DESCRIPTION
Hi, Thank you for the good library.

this patch will fix the installation error for 1.2.0-alpha.

the error came from dataclasses pkg requirements on setup.py. it was embeded in default python from 3.7.
