### PR TITLE
closes #848 - allows custom formatters for arguments

### DIFF
--- a/gooey/gui/components/widgets/bases.py
+++ b/gooey/gui/components/widgets/bases.py
@@ -196,10 +196,18 @@ class TextContainer(BaseWidget):
                    else eval('lambda user_input: bool(%s)' % userValidator)
         satisfies = testFunc if self._meta['required'] else ifPresent(testFunc)
         value = self.getWidgetValue()
+        cmd = self.formatOutput(self._meta, value)
+        if 'cli_formatter' in self._options:
+            cmd = self._options['cli_formatter'].format(cmd=cmd,
+                                                        value=value,
+                                                        id=self._id,
+                                                        meta=self._meta,
+                                                        options=self._options,
+                                                        dest=self._meta.get('dest'))
 
         return t.FieldValue(  # type: ignore
             id=self._id,
-            cmd=self.formatOutput(self._meta, value),
+            cmd=cmd,
             meta=self._meta,
             rawValue= value,
             # type=self.info['type'],

--- a/gooey/tests/test_common.py
+++ b/gooey/tests/test_common.py
@@ -50,5 +50,33 @@ class TestCommonProperties(unittest.TestCase):
                         self.assertEqual(widget.getValue()['rawValue'], case.initialExpected)
 
 
+    def testCustomFormatter(self):
+        widgets = ['ColourChooser',
+                   'CommandField',
+                   'DateChooser', 'DirChooser', 'FileChooser', 'FileSaver',
+                   'FilterableDropdown',  'MultiDirChooser', 'MultiFileChooser',
+                   'PasswordField',  'TextField', 'Textarea', 'TimeChooser']
+
+        cases = [
+            Case(
+                {'default': 'default'},
+                 '--widget \'default\''),
+            Case(
+                {'default': 'default', 'gooey_options': {'cli_formatter': 'test=value'}},
+                'test=value'),
+            Case(
+                {'default': 'default', 'gooey_options': {'cli_formatter': '{dest}={value}'}},
+                'widget=default'),
+        ]
+
+        for widgetName in widgets:
+            with self.subTest(widgetName):
+                for case in cases:
+                    parser = self.makeParser(widget=widgetName, **case.inputs)
+                    with instrumentGooey(parser) as (app, gooeyApp):
+                        widget = gooeyApp.configs[0].reifiedWidgets[0]
+                        self.assertEqual(widget.getValue()['cmd'], case.initialExpected)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Issue is [here](https://github.com/chriskiehl/Gooey/issues/848). For the second crazy example, I used the following mapshaper command which could not previously be reproduced with Gooey:

```
mapshaper -i 'cb_2020_us_county_500k.shp' \
    -each 'JOIN_FIPS="USA-" + GEOID' \
    --join 'us-counties-recent.csv' keys=JOIN_FIPS,geoid \
    -classify field=cases_avg_per_100k save-as=fill \
    colors=Magma invert breaks=10,30,50,70,100,250 \
    -proj 'albersusa' \
    -simplify '2%' \
    -o 'out.svg'
```

With this PR, you can now use `cli_formatter` with `gooey_options` to make it happen:

```python
@Gooey(target="mapshaper", suppress_gooey_flag=True) 
def main():
  parser = GooeyParser(description="Input data")

  inputs = parser.add_argument_group('Joining util')
  inputs.add_argument('-i',
                      metavar='Input Shapefile',
                      default='cb_2020_us_county_500k.shp',
                      widget='FileChooser')

  inputs.add_argument('-each',
                      default='JOIN_FIPS="USA-" + GEOID',
                      metavar='Do a thing for each row')

  inputs.add_argument('--join',
                      metavar='Input CSV',
                      default='us-counties-recent.csv')

  inputs.add_argument('--keys',
                      default='JOIN_FIPS,geoid',
                      metavar='Join key',
                      gooey_options={ 'cli_formatter': '{dest}={value}'})
  
  colors = parser.add_argument_group('Coloring')

  colors.add_argument('-classify', gooey_options= {'visible': False, 'cli_formatter': '{id}'})
  colors.add_argument('--field', default='cases_avg_per_100k', gooey_options= {'cli_formatter': '{dest}={value}'})
  colors.add_argument('--save-as', default='fill', gooey_options= {'cli_formatter': 'save-as={value}'})
  colors.add_argument('--colors', default='Magma', gooey_options= {'cli_formatter': '{dest}={value}'})
  colors.add_argument('--invert', default=True, action='store_true', gooey_options={ 'cli_formatter': '{dest}'})
  colors.add_argument('--breaks', default='10,30,50,70,100,250', gooey_options= {'cli_formatter': '{dest}={value}'})

  viz = parser.add_argument_group('Visualization')

  viz.add_argument('-proj',
                      metavar='Projection',
                      default='albersusa',
                      choices=['albersusa', 'merc','lcc','aea'])

  viz.add_argument('-simplify',
                      metavar='Simplify',
                      default='2%')

  output = parser.add_argument_group('Output')
  output.add_argument('-o',
                      metavar='Output file',
                      default='out.svg',
                      widget='FileChooser')

  args = parser.parse_args()

if __name__ == '__main__':
  main()
```

Beyond the basics of formatting as `key=value` or adding percentages/etc, you can use fun tricks like forcing optional parameters to be positional, in case `--` is not supported, as it can sidestep the "is this positional?" check. Lots of new flexibility!

Checklist:

 - [X] You're opening this PR against the current [release branch](https://github.com/chriskiehl/Gooey/blob/master/CONTRIBUTING.md#development-overview)
 - [X] Works on both Python 2.7 & Python 3.x
   - **Tested on 3, but not 2. Nothing crazy or especially modern in there so it should be fine, though.**
 - [X] Commits have been squashed and includes the relevant issue number
 - [X] Pull request description contains link to relevant issue or detailed notes on changes
 - [X] This **must** include example code demonstrating your feature or the bug being fixed
 - [X] All existing tests pass 
 - [X] Your bug fix / feature has associated test coverage 
 - [X] README.md is updated (if relevant)
   - **Didn't want to write up the `gooey_options` until confirmed that it gets a thumbs up**
