### PR TITLE
Change "is not" to "!=" when checking literals

### DIFF
--- a/gooey/gui/components/widgets/bases.py
+++ b/gooey/gui/components/widgets/bases.py
@@ -183,7 +183,7 @@ class TextContainer(BaseWidget):
     def syncUiState(self, state: FormField):  # type: ignore
         self.widget.setValue(state['value'])  # type: ignore
         self.error.SetLabel(state['error'] or '')
-        self.error.Show(state['error'] is not None and state['error'] is not '')
+        self.error.Show(state['error'] is not None and state['error'] != '')
 
 
     def getValue(self) -> t.FieldValue:

--- a/gooey/gui/components/widgets/checkbox.py
+++ b/gooey/gui/components/widgets/checkbox.py
@@ -71,7 +71,7 @@ class CheckBox(TextContainer):
         checkbox.Enable(state['enabled'])
         self.Show(state['visible'])
         self.error.SetLabel(state['error'] or '')
-        self.error.Show(state['error'] is not None and state['error'] is not '')
+        self.error.Show(state['error'] is not None and state['error'] != '')
 
 
 

--- a/gooey/gui/components/widgets/dropdown.py
+++ b/gooey/gui/components/widgets/dropdown.py
@@ -52,7 +52,7 @@ class Dropdown(TextContainer):
         if state['selected'] is not None:  # type: ignore
             self.setValue(state['selected'])  # type: ignore
         self.error.SetLabel(state['error'] or '')
-        self.error.Show(state['error'] is not None and state['error'] is not '')
+        self.error.Show(state['error'] is not None and state['error'] != '')
 
     def getUiState(self) -> t.FormField:
         widget: wx.ComboBox = self.widget

--- a/gooey/gui/components/widgets/dropdown_filterable.py
+++ b/gooey/gui/components/widgets/dropdown_filterable.py
@@ -128,7 +128,7 @@ class FilterableDropdown(Dropdown):
         if state['value'] is not None:
             self.setValue(state['value'])
         self.error.SetLabel(state['error'] or '')
-        self.error.Show(state['error'] is not None and state['error'] is not '')
+        self.error.Show(state['error'] is not None and state['error'] != '')
 
     def OnGetItem(self, n):
         return self.model.suggestions[n]

--- a/gooey/gui/components/widgets/listbox.py
+++ b/gooey/gui/components/widgets/listbox.py
@@ -51,4 +51,4 @@ class Listbox(TextContainer):
         for string in state['selected']:
             widget.SetStringSelection(string)
         self.error.SetLabel(state['error'] or '')
-        self.error.Show(state['error'] is not None and state['error'] is not '')
+        self.error.Show(state['error'] is not None and state['error'] != '')

--- a/gooey/gui/components/widgets/textarea.py
+++ b/gooey/gui/components/widgets/textarea.py
@@ -41,7 +41,7 @@ class Textarea(TextContainer):
     def syncUiState(self, state: FormField):
         self.setValue(state['value'])  # type: ignore
         self.error.SetLabel(state['error'] or '')
-        self.error.Show(state['error'] is not None and state['error'] is not '')
+        self.error.Show(state['error'] is not None and state['error'] != '')
 
     def getUiState(self) -> t.FormField:
         return t.TextField(

--- a/gooey/gui/components/widgets/textfield.py
+++ b/gooey/gui/components/widgets/textfield.py
@@ -27,5 +27,5 @@ class TextField(TextContainer):
         textctr.Enable(state['enabled'])
         self.Show(state['visible'])
         self.error.SetLabel(state['error'] or '')
-        self.error.Show(state['error'] is not None and state['error'] is not '')
+        self.error.Show(state['error'] is not None and state['error'] != '')
         self.Layout()


### PR DESCRIPTION
In a most widget files `is not` is used to check the error against an empty string (`''`). This doesn't work all the time [to my knowledge](https://stackoverflow.com/questions/2209755/python-operation-vs-is-not), so it is best to replace it with "!=", which is an equality check.

**Example**

Before:
```py
def syncUiState(self, state: FormField):  # type: ignore
        self.widget.setValue(state['value'])  # type: ignore
        self.error.SetLabel(state['error'] or '')
        self.error.Show(state['error'] is not None and state['error'] is not '')
```
After:
```py
def syncUiState(self, state: FormField):  # type: ignore
        self.widget.setValue(state['value'])  # type: ignore
        self.error.SetLabel(state['error'] or '')
        self.error.Show(state['error'] is not None and state['error'] != '')
#       --------------------------------------------------------------^^----
```
Checklist:
 - [x] You're opening this PR against the current [release branch](https://github.com/chriskiehl/Gooey/blob/master/CONTRIBUTING.md#development-overview)
 - [x] Works on both Python 2.7 & Python 3.x
 - [ ] Commits have been squashed and includes the relevant issue number

 Squashing is not necessary (only one commit) and there is no relevant issue.
 - [x] Pull request description contains link to relevant issue or detailed notes on changes
 - [x] This **must** include example code demonstrating your feature or the bug being fixed
 - [x] All existing tests pass
 - [ ] Your bug fix / feature has associated test coverage

N/A
 - [ ] README.md is updated (if relevant)

N/A