### PR TITLE
resolve #763 -- choose multiselect for options with choices and nargs=+ or *

### DIFF
--- a/gooey/python_bindings/argparse_to_json.py
+++ b/gooey/python_bindings/argparse_to_json.py
@@ -304,6 +304,8 @@ def categorize(actions, widget_dict, options):
             # pre-fill the 'counter' dropdown
             _json['data']['choices'] = list(map(str, range(0, 11)))
             yield _json
+        elif is_listbox(action):
+            yield action_to_json(action, _get_widget(action, 'Listbox'), options)
         else:
             raise UnknownWidgetType(action)
 
@@ -352,7 +354,7 @@ def is_optional(action):
 
 def is_choice(action):
     ''' action with choices supplied '''
-    return action.choices
+    return action.choices and not action.nargs
 
 def is_file(action):
     ''' action with FileType '''
@@ -402,6 +404,13 @@ def is_flag(action):
 def is_counter(action):
     """ _actions which are of type _CountAction """
     return isinstance(action, _CountAction)
+
+
+def is_listbox(action):
+    """ _actions whic can be translated into a Listbox """
+    return (isinstance(action, _StoreAction)
+            and action.choices
+            and action.nargs in {'+', '*'})
 
 
 def is_default_progname(name, subparser):

--- a/gooey/tests/test_argparse_to_json.py
+++ b/gooey/tests/test_argparse_to_json.py
@@ -290,3 +290,19 @@ class TestArgparse(unittest.TestCase):
                 result = next(argparse_to_json.categorize(action, {}, {}))
                 self.assertEqual(result['type'], expected_widget)
 
+
+    def test_nargs_with_choices_chooses_good_widget(self):
+        """
+        #763 argument with nargs in {+, *} and a list of choices should use
+        a Listbox widget
+        """
+        cases = ['*', '+']
+
+        for nargs in cases:
+            with self.subTest(f'expect {nargs} to produce a Listbox'):
+                parser = ArgumentParser()
+                parser.add_argument('foo', nargs=nargs, choices=['choice', 'choice1'])
+                action = [parser._actions[-1]]
+                result = next(argparse_to_json.categorize(action, {}, {}))
+                self.assertEqual(result['type'], 'Listbox')
+


### PR DESCRIPTION
fix #763

Example:
```python
from gooey import Gooey, GooeyParser


@Gooey
def main():
    parser = GooeyParser()
    parser.add_argument(
        'some_argument',
        nargs='+',
        choices=['jaca', 'paca'],
    )
    argv = parser.parse_args()

    print(argv.some_argument)


if __name__ == '__main__':
    main()
```

TL;DR: 

 - [x] You're opening this PR against the current [release branch](https://github.com/chriskiehl/Gooey/blob/master/CONTRIBUTING.md#development-overview)
 - [x] Works on both Python 2.7 & Python 3.x
 - [x] Commits have been squashed and includes the relevant issue number
 - [x] Pull request description contains link to relevant issue or detailed notes on changes
  - [x] This **must** include example code demonstrating your feature or the bug being fixed
 - [x] All existing tests pass 
 - [x] Your bug fix / feature has associated test coverage 
