### PR TITLE
Fix example typo in menu section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,7 +439,7 @@ Each map is made up of two key/value pairs
 You can have as many menu groups as you want. They're passed as a list to the `menu` argument on the `@Gooey` decorator.
 
 ```
-@Gooey(menu=[{'name': 'File', 'items: []},
+@Gooey(menu=[{'name': 'File', 'items': []},
              {'name': 'Tools', 'items': []},
              {'name': 'Help', 'items': []}])
 ```


### PR DESCRIPTION
Fixed typo in README.md menu section where example missed the closing apostrophe from the first items key.