### PR TITLE
Update chooser.py

### DIFF
--- a/gooey/gui/components/widgets/core/chooser.py
+++ b/gooey/gui/components/widgets/core/chooser.py
@@ -123,8 +123,9 @@ class DirChooser(Chooser):
     """ Retrieve a path to the supplied directory """
     def getDialog(self):
         options = self.Parent._options
+        pathValue = self.getValue()
         return wx.DirDialog(self, message=options.get('message', _('choose_folder')),
-                            defaultPath=options.get('default_path', os.getcwd()))
+                            defaultPath=pathValue)
 
 class MultiDirChooser(Chooser):
     """ Retrieve multiple directories from the system """


### PR DESCRIPTION
fix: update default_path with the actual widget value
This is a small change which is useful for remembering the previous chosen folder, otherwise it gives default_path which is initiated at the first time.

Make sure you've followed the [Contributing](https://github.com/chriskiehl/Gooey/blob/master/CONTRIBUTING.md) guidelines before finalizing your pull request. 

TL;DR: 

 - [x] You're opening this PR against the current [release branch](https://github.com/chriskiehl/Gooey/blob/master/CONTRIBUTING.md#development-overview)
 - [x] Works on both Python 2.7 & Python 3.x
 - [x] Commits have been squashed and includes the relevant issue number
 - [x] Pull request description contains link to relevant issue or detailed notes on changes
  - [x] This **must** include example code demonstrating your feature or the bug being fixed
 - [x] All existing tests pass 
 - [x] Your bug fix / feature has associated test coverage 
 - [x] README.md is updated (if relevant)
