### PR TITLE
packaging: fix up osx exe strip kwarg

### DIFF
--- a/docs/packaging/build-osx.spec
+++ b/docs/packaging/build-osx.spec
@@ -42,7 +42,7 @@ exe = EXE(pyz,
           gooey_images,
           name='APPNAME',
           debug=False,
-          strip=None,
+          strip=False,
           upx=True,
           console=False,
           icon=os.path.join(gooey_root, 'images', 'program_icon.ico'))


### PR DESCRIPTION
In the pyinstaller build-osx.spec file included as a reference and starting point, the 'strip=None' keyword argument passed into pyinstaller's EXE definition causes a runtime exception in a string format. Its default is False. This change sets it explicitly to False.

Fixes issue #930
In the pyinstaller build-osx.spec file included as a reference and starting point, the 'strip=None' keyword argument passed into pyinstaller's EXE definition causes a runtime exception in a string format. Its default is False. This change sets it explicitly to False.

Fixes issue 930: [https://github.com/chriskiehl/Gooey/issues/930](url)

Before, using the examples/simple_demo.py program:
```
gooey_examples % pyinstaller build-osx.spec
...
Traceback (most recent call last):
  File "/Users/simon/Documents/gooey_examples/bin/pyinstaller", line 8, in <module>
    sys.exit(_console_script_run())
  File "/Users/simon/Documents/gooey_examples/lib/python3.9/site-packages/PyInstaller/__main__.py", line 231, in _console_script_run
    run()
  File "/Users/simon/Documents/gooey_examples/lib/python3.9/site-packages/PyInstaller/__main__.py", line 215, in run
    run_build(pyi_config, spec_file, **vars(args))
  File "/Users/simon/Documents/gooey_examples/lib/python3.9/site-packages/PyInstaller/__main__.py", line 70, in run_build
    PyInstaller.building.build_main.main(pyi_config, spec_file, **kwargs)
  File "/Users/simon/Documents/gooey_examples/lib/python3.9/site-packages/PyInstaller/building/build_main.py", line 1270, in main
    build(specfile, distpath, workpath, clean_build)
  File "/Users/simon/Documents/gooey_examples/lib/python3.9/site-packages/PyInstaller/building/build_main.py", line 1208, in build
    exec(code, spec_namespace)
  File "build-osx.spec", line 35, in <module>
    exe = EXE(pyz,
  File "/Users/simon/Documents/gooey_examples/lib/python3.9/site-packages/PyInstaller/building/api.py", line 646, in __init__
    self.pkg = PKG(
  File "/Users/simon/Documents/gooey_examples/lib/python3.9/site-packages/PyInstaller/building/api.py", line 254, in __init__
    self.__postinit__()
  File "/Users/simon/Documents/gooey_examples/lib/python3.9/site-packages/PyInstaller/building/datastruct.py", line 184, in __postinit__
    self.assemble()
  File "/Users/simon/Documents/gooey_examples/lib/python3.9/site-packages/PyInstaller/building/api.py", line 314, in assemble
    src_name = process_collected_binary(
  File "/Users/simon/Documents/gooey_examples/lib/python3.9/site-packages/PyInstaller/building/utils.py", line 179, in process_collected_binary
    f'bincache{use_strip:d}{use_upx:d}{pyver}{arch}',
TypeError: unsupported format string passed to NoneType.__format__
```

After, with this patch applied:
```
gooey_examples % pyinstaller build-osx.spec
...
11726 INFO: Building BUNDLE BUNDLE-00.toc
11743 INFO: Signing the BUNDLE...
11896 INFO: Building BUNDLE BUNDLE-00.toc completed successfully.
11896 INFO: Build complete! The results are available in: /Users/simon/Documents/gooey_examples/dist
```

 - [x ] You're opening this PR against the current [release branch](https://github.com/chriskiehl/Gooey/blob/master/CONTRIBUTING.md#development-overview)
 - [x] Works on both Python 2.7 & Python 3.x
 - [x] Commits have been squashed and includes the relevant issue number
 - [x] Pull request description contains link to relevant issue or detailed notes on changes
 - [x] This **must** include example code demonstrating your feature or the bug being fixed
 - [?] All existing tests pass 
 - [?] Your bug fix / feature has associated test coverage 
 - [x] README.md is updated (if relevant)
