### PR TITLE
Fix Python runtime warnings

### DIFF
--- a/gooey/gui/components/options/options.py
+++ b/gooey/gui/components/options/options.py
@@ -212,7 +212,7 @@ def FilterableDropdown(placeholder=None,
 
 def PrefixSearchStrategy(
                    choice_tokenizer=PrefixTokenizers.WORDS,
-                   input_tokenizer=PrefixTokenizers.REGEX('\s'),
+                   input_tokenizer=PrefixTokenizers.REGEX(r'\s'),
                    ignore_case=True,
                    operator='AND',
                    index_suffix=False):
@@ -301,7 +301,7 @@ def RegexValidator(test=None, message=None):
     Creates the data for a basic RegexValidator.
 
     :param test:    the regex expression. This should be the expression
-                    directly (i.e. `test='\d+'`). Gooey will test
+                    directly (i.e. `test=r'\d+'`). Gooey will test
                     that the user's input satisfies this expression.
     :param message: The message to display if the input doesn't match
                     the regex

--- a/gooey/gui/components/options/validators.py
+++ b/gooey/gui/components/options/validators.py
@@ -73,7 +73,7 @@ def is_three_channeled(value):
 @lift
 def is_hex_string(value: str):
     """Invalid hexadecimal format. Expected: "#FFFFFF" """
-    return isinstance(value, str) and bool(re.match('^#[\dABCDEF]{6}$', value, flags=2))
+    return isinstance(value, str) and bool(re.match(r'^#[\dABCDEF]{6}$', value, flags=2))
 
 
 @lift

--- a/gooey/gui/components/widgets/bases.py
+++ b/gooey/gui/components/widgets/bases.py
@@ -183,7 +183,7 @@ class TextContainer(BaseWidget):
     def syncUiState(self, state: FormField):  # type: ignore
         self.widget.setValue(state['value'])  # type: ignore
         self.error.SetLabel(state['error'] or '')
-        self.error.Show(state['error'] is not None and state['error'] is not '')
+        self.error.Show(state['error'] is not None and state['error'] != '')
 
 
     def getValue(self) -> t.FieldValue:

--- a/gooey/gui/components/widgets/checkbox.py
+++ b/gooey/gui/components/widgets/checkbox.py
@@ -71,7 +71,7 @@ class CheckBox(TextContainer):
         checkbox.Enable(state['enabled'])
         self.Show(state['visible'])
         self.error.SetLabel(state['error'] or '')
-        self.error.Show(state['error'] is not None and state['error'] is not '')
+        self.error.Show(state['error'] is not None and state['error'] != '')
 
 
 

--- a/gooey/gui/components/widgets/dropdown.py
+++ b/gooey/gui/components/widgets/dropdown.py
@@ -52,7 +52,7 @@ class Dropdown(TextContainer):
         if state['selected'] is not None:  # type: ignore
             self.setValue(state['selected'])  # type: ignore
         self.error.SetLabel(state['error'] or '')
-        self.error.Show(state['error'] is not None and state['error'] is not '')
+        self.error.Show(state['error'] is not None and state['error'] != '')
 
     def getUiState(self) -> t.FormField:
         widget: wx.ComboBox = self.widget

--- a/gooey/gui/components/widgets/dropdown_filterable.py
+++ b/gooey/gui/components/widgets/dropdown_filterable.py
@@ -128,7 +128,7 @@ class FilterableDropdown(Dropdown):
         if state['value'] is not None:
             self.setValue(state['value'])
         self.error.SetLabel(state['error'] or '')
-        self.error.Show(state['error'] is not None and state['error'] is not '')
+        self.error.Show(state['error'] is not None and state['error'] != '')
 
     def OnGetItem(self, n):
         return self.model.suggestions[n]

--- a/gooey/gui/components/widgets/listbox.py
+++ b/gooey/gui/components/widgets/listbox.py
@@ -51,4 +51,4 @@ class Listbox(TextContainer):
         for string in state['selected']:
             widget.SetStringSelection(string)
         self.error.SetLabel(state['error'] or '')
-        self.error.Show(state['error'] is not None and state['error'] is not '')
+        self.error.Show(state['error'] is not None and state['error'] != '')

--- a/gooey/gui/components/widgets/textarea.py
+++ b/gooey/gui/components/widgets/textarea.py
@@ -41,7 +41,7 @@ class Textarea(TextContainer):
     def syncUiState(self, state: FormField):
         self.setValue(state['value'])  # type: ignore
         self.error.SetLabel(state['error'] or '')
-        self.error.Show(state['error'] is not None and state['error'] is not '')
+        self.error.Show(state['error'] is not None and state['error'] != '')
 
     def getUiState(self) -> t.FormField:
         return t.TextField(

--- a/gooey/gui/components/widgets/textfield.py
+++ b/gooey/gui/components/widgets/textfield.py
@@ -27,5 +27,5 @@ class TextField(TextContainer):
         textctr.Enable(state['enabled'])
         self.Show(state['visible'])
         self.error.SetLabel(state['error'] or '')
-        self.error.Show(state['error'] is not None and state['error'] is not '')
+        self.error.Show(state['error'] is not None and state['error'] != '')
         self.Layout()


### PR DESCRIPTION
Obvious fixes to suppress runtime warnings from Python regarding backslash escapes in strings and `is`/`is not` comparisons with string literals.