### PR TITLE
Replace getdefaultlocale() with getlocale()

### DIFF
--- a/gooey/tests/__init__.py
+++ b/gooey/tests/__init__.py
@@ -55,7 +55,7 @@ class TestApp(wx.App):
             self._initial_locale = None
             locale.setlocale(locale.LC_ALL, 'C')
         else:
-            lang, enc = locale.getdefaultlocale()
+            lang, enc = locale.getlocale()
             self._initial_locale = wx.Locale(lang, lang[:2], lang)
             locale.setlocale(locale.LC_ALL, lang)
 


### PR DESCRIPTION
`pytest`  is emitting a warning about `getdefaultlocale()` being removed in Python 3.15.

`getdefaultlocale()` is deprecated. The `getlocale()` function has been in Python forever, so it's a safe change.