### PR TITLE
widgets: change dropdown style to readonly

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Gooey does its best to choose sensible defaults based on the options it finds. C
 | store_const | CheckBox |<img src="https://github.com/chriskiehl/GooeyImages/raw/images/readme-images/f538c850-07c5-11e5-8cbe-864badfa54a9.png"/>|
 | store_true | CheckBox | <img src="https://github.com/chriskiehl/GooeyImages/raw/images/readme-images/f538c850-07c5-11e5-8cbe-864badfa54a9.png"/>|
 | store_False | CheckBox|  <img src="https://github.com/chriskiehl/GooeyImages/raw/images/readme-images/f538c850-07c5-11e5-8cbe-864badfa54a9.png"/>   |
+| version | CheckBox|  <img src="https://github.com/chriskiehl/GooeyImages/raw/images/readme-images/f538c850-07c5-11e5-8cbe-864badfa54a9.png"/>   |
 | append | TextCtrl |  <img src="https://github.com/chriskiehl/GooeyImages/raw/images/readme-images/f54e9f5e-07c5-11e5-86e5-82f011c538cf.png"/>  | 
 | count | DropDown &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | <img src="https://github.com/chriskiehl/GooeyImages/raw/images/readme-images/f53ccbe4-07c5-11e5-80e5-510e2aa22922.png"/> | 
 | Mutually Exclusive Group | RadioGroup | <img src="https://github.com/chriskiehl/GooeyImages/raw/images/readme-images/f553feb8-07c5-11e5-9d5b-eaa4772075a9.png"/>

--- a/docs/Gooey-Options.md
+++ b/docs/Gooey-Options.md
@@ -22,7 +22,8 @@ and with that, you're ready to rock.
 
 ## Overview
 
-* Global Style Options 
+* Global Style/Layout Options 
+* Global Config Options 
 * Custom Widget Options
     * Textarea
     * BlockCheckbox  
@@ -31,7 +32,7 @@ and with that, you're ready to rock.
 * Argument Group Options  
 
 
-## Global Widget Styles    
+## Global Style / Layout Options     
 
 All widgets in Gooey (with the exception of RadioGroups) are made up of three basic components. 
 
@@ -72,6 +73,17 @@ parser.add_argument('-my-arg', gooey_options={
 | full_width | bool | This is a layout hint for this widget. When `True` the widget will fill the entire available space within a given row. Otherwise, it will be sized based on the column rules provided elsewhere. | 
 
 
+## Global Config Options 
+
+> new in 1.0.8
+
+All widgets in Gooey accept an `initial_value` option to seed the UI. 
+
+```python
+parser.add_argument('-my-arg', widget='Textarea', gooey_options={
+    'initial_value': 'Hello world!'  
+})
+```
 
 ## Individual Widget Options
 

--- a/docs/releases/1.0.8-release-notes.md
+++ b/docs/releases/1.0.8-release-notes.md
@@ -1,0 +1,58 @@
+## Gooey 1.0.8 Released! 
+
+
+Another minor Gooey release! This one brings a new global Gooey Option for setting initial values in the UI, support for `version` action types, plus a few bug/linting fixes.
+
+Additionally, I continue to plug away at getting the test coverage to useful levels. We're now pushing 80% coverage which is making working on Gooey with confidence much easier!   
+
+
+### New Gooey Options: initial_value 
+
+This option lets you specify the value present in the widget when Gooey starts. 
+
+```python
+parser.add_argument('-my-arg', widget='Textarea', gooey_options={
+    'initial_value': 'Hello world!'  
+})
+```
+
+Or, using the new `options` helpers: 
+
+```python
+from gooey import options 
+parser.add_argument('-my-arg', widget='Textarea', gooey_options=options.Textarea(
+    initial_value='Hello World!'
+))
+```
+
+If you've been using Gooey awhile, you'll recognize that this overlaps with the current behavior of `default`. The new `initial_value` enables you to supply a truly optional seed value to the UI. When using `default`, even if the user clears your value out of the UI, argparse will add it back in when it parses the CLI string. While this is often useful behavior, it prevents certain workflows from being possible. `initial_value` let's you control the UI independent of argparse. This means you can now, for instance, set a checkbox to be checked by default in the UI, but optionally allow the user to deselect it without having argprase re-populate the 'checked' state (a behavior which comes up frequently in the issue tracker due to it being technically correct, but also very confusing!). 
+
+
+### action=version support 
+
+When using `action='version'` Gooey will now map it a CheckBox widget type. 
+
+
+### Other Fixes / Changes: 
+
+ * Bug fix: add missing translation step for tabbed group titles (@neonbunny)
+ * Linting: swap `is not` for `!=` (@DrStrinky) 
+
+
+## Breaking Changes 
+
+**No breaking API changes from 1.0.7 to 1.0.8**   
+
+
+## Thank you to the current [Patreon supporters](https://www.patreon.com/chriskiehl)! 
+
+* Sponsors: 
+    * Qteal
+* Individuals: 
+    * Joseph Rhodes
+    * Nicholas 
+    * Joey
+    
+
+    
+    

--- a/gooey/gui/components/config.py
+++ b/gooey/gui/components/config.py
@@ -211,7 +211,7 @@ class TabbedConfigPage(ConfigPage):
             self.makeGroup(panel, sizer, group, 0, wx.EXPAND)
             panel.SetSizer(sizer)
             panel.Layout()
-            self.notebook.AddPage(panel, group['name'])
+            self.notebook.AddPage(panel, self.getName(group))
             self.notebook.Layout()
 
 

--- a/gooey/gui/components/options/options.py
+++ b/gooey/gui/components/options/options.py
@@ -329,6 +329,6 @@ def ArgumentGroup(show_border=False,
 
 def _clean(options):
     cleaned = {k: v for k, v in options.items()
-               if v is not None and k is not "layout_options"}
+               if v is not None and k != "layout_options"}
     return {**options.get('layout_options', {}), **cleaned}
 

--- a/gooey/gui/components/options/options.py
+++ b/gooey/gui/components/options/options.py
@@ -11,6 +11,16 @@ def _include_layout_docs(f):
     return f
 
 
+def _include_global_option_docs(f):
+    """
+    Combines docstrings for options available to
+    all widget types.
+    """
+    _doc = """:param initial_value:  Sets the initial value in the UI. 
+    """
+    f.__doc__ = (f.__doc__ or '') + _doc
+    return f
+
 def _include_chooser_msg_wildcard_docs(f):
     """
     Combines the basic Chooser options (wildard, message) docsstring
@@ -74,18 +84,22 @@ def LayoutOptions(label_color=None,
     return _clean(locals())
 
 
+
 @_include_layout_docs
-def TextField(validator=None, **layout_options):
+@_include_global_option_docs
+def TextField(initial_value=None, validator=None, **layout_options):
     return _clean(locals())
 
 
 @_include_layout_docs
-def PasswordField(validator=None, **layout_options):
+@_include_global_option_docs
+def PasswordField(initial_value=None, validator=None, **layout_options):
     return _clean(locals())
 
 
 @_include_layout_docs
-def IntegerField(validator=None, min=0, max=100, increment=1, **layout_options):
+@_include_global_option_docs
+def IntegerField(initial_value=None, validator=None, min=0, max=100, increment=1, **layout_options):
     """
     :param min: The minimum value allowed
     :param max: The maximum value allowed
@@ -94,7 +108,8 @@ def IntegerField(validator=None, min=0, max=100, increment=1, **layout_options):
     return _clean(locals())
 
 @_include_layout_docs
-def Slider(validator=None, min=0, max=100, increment=1, **layout_options):
+@_include_global_option_docs
+def Slider(initial_value=None, validator=None, min=0, max=100, increment=1, **layout_options):
     """
     :param min: The minimum value allowed
     :param max: The maximum value allowed
@@ -104,7 +119,9 @@ def Slider(validator=None, min=0, max=100, increment=1, **layout_options):
 
 
 @_include_layout_docs
+@_include_global_option_docs
 def DecimalField(validator=None,
+                 initial_value=None,
                  min=0.0,
                  max=1.0,
                  increment=0.01,
@@ -120,7 +137,8 @@ def DecimalField(validator=None,
 
 
 @_include_layout_docs
-def TextArea(height=None, readonly=False, validator=None, **layout_options):
+@_include_global_option_docs
+def TextArea(initial_value=None, height=None, readonly=False, validator=None, **layout_options):
     """
     :param height:   The height of the TextArea.
     :param readonly: Controls whether or not user's may modify the contents
@@ -129,12 +147,14 @@ def TextArea(height=None, readonly=False, validator=None, **layout_options):
 
 
 @_include_layout_docs
+@_include_global_option_docs
 def RichTextConsole(**layout_options):
     return _clean(locals())
 
 
 @_include_layout_docs
-def ListBox(height=None, **layout_options):
+@_include_global_option_docs
+def ListBox(initial_value=None, height=None, **layout_options):
     """
     :param height: The height of the ListBox
     """
@@ -150,30 +170,36 @@ def MutexGroup(initial_selection=None, title=None, **layout_options):
 
 
 @_include_layout_docs
-def Dropdown(**layout_options):
+@_include_global_option_docs
+def Dropdown(initial_value=None, **layout_options):
     return _clean(locals())
 
 
 @_include_layout_docs
-def Counter(**layout_options):
+@_include_global_option_docs
+def Counter(initial_value=None, **layout_options):
     return _clean(locals())
 
 
 @_include_layout_docs
-def CheckBox(**layout_options):
+@_include_global_option_docs
+def CheckBox(initial_value=None, **layout_options):
     return _clean(locals())
 
 
 @_include_layout_docs
-def BlockCheckBox(checkbox_label=None, **layout_options):
+@_include_global_option_docs
+def BlockCheckBox(initial_value=None, checkbox_label=None, **layout_options):
     return _clean(locals())
 
 
 @_include_layout_docs
+@_include_global_option_docs
 def FilterableDropdown(placeholder=None,
                        empty_message=None,
                        max_size=80,
                        search_strategy=None,
+                       initial_value=None,
                        **layout_options):
     """
     :param placeholder:     Text to display when the user has provided no input
@@ -205,21 +231,25 @@ def PrefixSearchStrategy(
 
 
 @_include_layout_docs
+@_include_global_option_docs
 @_include_choose_dir_file_docs
 @_include_chooser_msg_wildcard_docs
 def FileChooser(wildcard=None,
                 default_dir=None,
                 default_file=None,
                 message=None,
+                initial_value=None,
                 **layout_options):
     return _clean(locals())
 
 
 @_include_layout_docs
+@_include_global_option_docs
 @_include_chooser_msg_wildcard_docs
 def DirectoryChooser(wildcard=None,
                     default_path=None,
                     message=None,
+                    initial_value=None,
                     **layout_options):
     """
     :param default_path: The default path selected when the dialog spawns
@@ -228,23 +258,27 @@ def DirectoryChooser(wildcard=None,
 
 
 @_include_layout_docs
+@_include_global_option_docs
 @_include_choose_dir_file_docs
 @_include_chooser_msg_wildcard_docs
 def FileSaver(wildcard=None,
               default_dir=None,
               default_file=None,
               message=None,
+              initial_value=None,
               **layout_options):
     return _clean(locals())
 
 
 @_include_layout_docs
+@_include_global_option_docs
 @_include_choose_dir_file_docs
 @_include_chooser_msg_wildcard_docs
 def MultiFileSaver(wildcard=None,
               default_dir=None,
               default_file=None,
               message=None,
+              initial_value=None,
               **layout_options):
     return _clean(locals())
 

--- a/gooey/gui/components/widgets/bases.py
+++ b/gooey/gui/components/widgets/bases.py
@@ -76,8 +76,12 @@ class TextContainer(BaseWidget):
         self.SetSizer(self.layout)
         self.bindMouseEvents()
         self.Bind(wx.EVT_SIZE, self.onSize)
+
+        # 1.0.7 initial_value should supersede default when both are present
+        if self._options.get('initial_value') is not None:
+            self.setValue(self._options['initial_value'])
         # Checking for None instead of truthiness means False-evaluaded defaults can be used.
-        if self._meta['default'] is not None:
+        elif self._meta['default'] is not None:
             self.setValue(self._meta['default'])
 
         if self._options.get('placeholder'):

--- a/gooey/gui/components/widgets/dropdown.py
+++ b/gooey/gui/components/widgets/dropdown.py
@@ -21,7 +21,7 @@ class Dropdown(TextContainer):
             # str conversion allows using stringyfiable values in addition to pure strings
             value=str(default),
             choices=[str(default)] + [str(choice) for choice in self._meta['choices']],
-            style=wx.CB_DROPDOWN)
+            style=wx.CB_READONLY)
 
     def setOptions(self, options):
         with self.retainSelection():

--- a/gooey/python_bindings/argparse_to_json.py
+++ b/gooey/python_bindings/argparse_to_json.py
@@ -12,7 +12,8 @@ from argparse import (
     _StoreFalseAction,
     _StoreTrueAction,
     _StoreAction,
-    _SubParsersAction)
+    _SubParsersAction,
+    _VersionAction)
 from collections import OrderedDict
 from functools import partial
 from uuid import uuid4
@@ -277,8 +278,10 @@ def categorize2(groups, widget_dict, options):
 def categorize(actions, widget_dict, options):
     _get_widget = partial(get_widget, widget_dict)
     for action in actions:
+        if is_version(action):
+            yield action_to_json(action, _get_widget(action, 'CheckBox'), options)
 
-        if is_mutex(action):
+        elif is_mutex(action):
             yield build_radio_group(action, widget_dict, options)
 
         elif is_standard(action):
@@ -351,6 +354,9 @@ def is_choice(action):
 def is_file(action):
     ''' action with FileType '''
     return isinstance(action.type, argparse.FileType)
+
+def is_version(action):
+    return isinstance(action, _VersionAction)
 
 def is_standard(action):
     """ actions which are general "store" instructions.

--- a/gooey/python_bindings/argparse_to_json.py
+++ b/gooey/python_bindings/argparse_to_json.py
@@ -429,9 +429,14 @@ def action_to_json(action, widget, options):
         },
     })
 
-    default = handle_default(action, widget)
+    if (options.get(action.dest) or {}).get('initial_value') != None:
+        value = options[action.dest]['initial_value']
+        options[action.dest]['initial_value'] = handle_initial_values(action, widget, value)
+    default = handle_initial_values(action, widget, action.default)
     if default == argparse.SUPPRESS:
         default = None
+
+
 
     final_options = merge(base, options.get(action.dest) or {})
     validate_gooey_options(action, widget, final_options)
@@ -494,7 +499,6 @@ def coerce_default(default, widget):
         'Dropdown': safe_string,
         'Counter': safe_string
     }
-
     # Issue #321:
     # Defaults for choice types must be coerced to strings
     # to be able to match the stringified `choices` used by `wx.ComboBox`
@@ -505,7 +509,7 @@ def coerce_default(default, widget):
     return dispatcher.get(widget, identity)(cleaned)
 
 
-def handle_default(action, widget):
+def handle_initial_values(action, widget, value):
     handlers = [
         [textinput_with_nargs_and_list_default, coerse_nargs_list],
         [is_widget('Listbox'), clean_list_defaults],
@@ -514,8 +518,8 @@ def handle_default(action, widget):
     ]
     for matches, apply_coercion in handlers:
         if matches(action, widget):
-            return apply_coercion(action.default)
-    return clean_default(action.default)
+            return apply_coercion(value)
+    return clean_default(value)
 
 
 def coerse_nargs_list(default):

--- a/gooey/tests/test_argparse_to_json.py
+++ b/gooey/tests/test_argparse_to_json.py
@@ -155,6 +155,26 @@ class TestArgparse(unittest.TestCase):
             self.assertEqual(getin(item, ['data', 'default']), None)
 
 
+    def test_version_maps_to_checkbox(self):
+        testcases = [
+            [['--version'], {}, 'TextField'],
+            # we only remap if the action is version
+            # i.e. we don't care about the argument name itself
+            [['--version'], {'action': 'store'}, 'TextField'],
+            # should get mapped to CheckBox becuase of the action
+            [['--version'], {'action': 'version'}, 'CheckBox'],
+            # ditto, even through the 'name' isn't 'version'
+            [['--foobar'], {'action': 'version'}, 'CheckBox'],
+        ]
+        for args, kwargs, expectedType in testcases:
+            with self.subTest([args, kwargs]):
+                parser = argparse.ArgumentParser(prog='test')
+                parser.add_argument(*args, **kwargs)
+                result = argparse_to_json.convert(parser, num_required_cols=2, num_optional_cols=2)
+                contents = getin(result, ['widgets', 'test', 'contents'])[0]
+                self.assertEqual(contents['items'][0]['type'], expectedType)
+
+
     def test_textinput_with_list_default_mapped_to_cli_friendly_value(self):
         """
         Issue: #500

--- a/gooey/tests/test_argparse_to_json.py
+++ b/gooey/tests/test_argparse_to_json.py
@@ -190,7 +190,7 @@ class TestArgparse(unittest.TestCase):
                 parser = ArgumentParser(prog='test_program')
                 parser.add_argument('--foo', nargs=case['nargs'], default=case['default'])
                 action = parser._actions[-1]
-                result = argparse_to_json.handle_default(action, case['w'])
+                result = argparse_to_json.handle_initial_values(action, case['w'], action.default)
                 self.assertEqual(result, case['gooey_default'])
 
     def test_nargs(self):

--- a/gooey/tests/test_checkbox.py
+++ b/gooey/tests/test_checkbox.py
@@ -1,0 +1,58 @@
+import unittest
+
+from tests.harness import instrumentGooey
+from gooey import GooeyParser
+from gooey.tests import *
+
+
+
+class TestCheckbox(unittest.TestCase):
+
+    def makeParser(self, **kwargs):
+        parser = GooeyParser(description='description')
+        parser.add_argument(
+            '--widget',
+            action='store_true',
+            **kwargs)
+        return parser
+
+
+    def testInitialValue(self):
+        cases = [
+            # `initial` should supersede `default`
+            {'inputs': {'default': False,
+                        'widget': 'CheckBox',
+                        'gooey_options': {'initial_value': True}},
+             'expect': True},
+
+            {'inputs': {'gooey_options': {'initial_value': True},
+                        'widget': 'CheckBox'},
+             'expect': True},
+
+            {'inputs': {'gooey_options': {'initial_value': False},
+                        'widget': 'CheckBox'},
+             'expect': False},
+
+            {'inputs': {'default': True,
+                        'widget': 'CheckBox',
+                        'gooey_options': {}},
+             'expect': True},
+
+            {'inputs': {'default': True,
+                        'widget': 'CheckBox'},
+             'expect': True},
+
+            {'inputs': {'widget': 'CheckBox'},
+             'expect': False}
+        ]
+        for case in cases:
+            with self.subTest(case):
+                parser = self.makeParser(**case['inputs'])
+                with instrumentGooey(parser) as (app, gooeyApp):
+                    widget = gooeyApp.configs[0].reifiedWidgets[0]
+                    self.assertEqual(widget.getValue()['rawValue'], case['expect'])
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/gooey/tests/test_common.py
+++ b/gooey/tests/test_common.py
@@ -1,0 +1,54 @@
+import unittest
+from collections import namedtuple
+
+from tests.harness import instrumentGooey
+from gooey import GooeyParser
+from gooey.tests import *
+
+Case = namedtuple('Case', 'inputs initialExpected')
+
+
+class TestCommonProperties(unittest.TestCase):
+    """
+    Test options and functionality
+    common across all widgets.
+    """
+
+    def makeParser(self, **kwargs):
+        parser = GooeyParser(description='description')
+        parser.add_argument('--widget', **kwargs)
+        return parser
+
+    def testInitialValue(self):
+        widgets = ['ColourChooser',
+                   'CommandField',
+                   'DateChooser', 'DirChooser', 'FileChooser', 'FileSaver',
+                   'FilterableDropdown',  'MultiDirChooser', 'MultiFileChooser',
+                   'PasswordField',  'TextField', 'Textarea', 'TimeChooser']
+
+        cases = [
+            # initial_value supersedes, default
+            Case(
+                {'default': 'default', 'gooey_options': {'initial_value': 'some val'}},
+                'some val'),
+            Case(
+                {'gooey_options': {'initial_value': 'some val'}},
+                 'some val'),
+            Case(
+                {'default': 'default', 'gooey_options': {}},
+                 'default'),
+            Case({'default': 'default'},
+                 'default')
+        ]
+
+        for widgetName in widgets:
+            with self.subTest(widgetName):
+                for case in cases:
+                    parser = self.makeParser(widget=widgetName, **case.inputs)
+                    with instrumentGooey(parser) as (app, gooeyApp):
+                        widget = gooeyApp.configs[0].reifiedWidgets[0]
+                        self.assertEqual(widget.getValue()['rawValue'], case.initialExpected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/gooey/tests/test_counter.py
+++ b/gooey/tests/test_counter.py
@@ -1,0 +1,51 @@
+import unittest
+
+from tests.harness import instrumentGooey
+from gooey import GooeyParser
+from gooey.tests import *
+
+
+
+class TestCounter(unittest.TestCase):
+
+    def makeParser(self, **kwargs):
+        parser = GooeyParser(description='description')
+        parser.add_argument(
+            '--widget',
+            action='count',
+            widget="Counter",
+            **kwargs)
+        return parser
+
+
+    def testInitialValue(self):
+        cases = [
+            # `initial` should supersede `default`
+            {'inputs': {'default': 1,
+                        'gooey_options': {'initial_value': 3}},
+             'expect': '3'},
+
+            {'inputs': {'gooey_options': {'initial_value': 1}},
+             'expect': '1'},
+
+            {'inputs': {'default': 2,
+                        'gooey_options': {}},
+             'expect': '2'},
+
+            {'inputs': {'default': 1},
+             'expect': '1'},
+
+            {'inputs': {},
+             'expect': None}
+        ]
+        for case in cases:
+            with self.subTest(case):
+                parser = self.makeParser(**case['inputs'])
+                with instrumentGooey(parser) as (app, gooeyApp):
+                    widget = gooeyApp.configs[0].reifiedWidgets[0]
+                    self.assertEqual(widget.getValue()['rawValue'], case['expect'])
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/gooey/tests/test_listbox.py
+++ b/gooey/tests/test_listbox.py
@@ -1,0 +1,58 @@
+import unittest
+
+from tests.harness import instrumentGooey
+from gooey import GooeyParser
+from gooey.tests import *
+
+
+
+class TestListbox(unittest.TestCase):
+
+    def makeParser(self, **kwargs):
+        parser = GooeyParser(description='description')
+        parser.add_argument(
+            '--widget',
+            widget="Listbox",
+            nargs="*",
+            **kwargs)
+        return parser
+
+    def testInitialValue(self):
+        cases = [
+            # `initial` should supersede `default`
+            {'inputs': {'default': 'b',
+                        'choices': ['a', 'b', 'c'],
+                        'gooey_options': {'initial_value': 'a'}},
+             'expect': ['a']},
+
+            {'inputs': {'choices': ['a', 'b', 'c'],
+                        'gooey_options': {'initial_value': 'a'}},
+             'expect': ['a']},
+
+            {'inputs': {'choices': ['a', 'b', 'c'],
+                        'gooey_options': {'initial_value': ['a', 'c']}},
+             'expect': ['a', 'c']},
+
+            {'inputs': {'choices': ['a', 'b', 'c'],
+                        'default': 'b',
+                        'gooey_options': {}},
+             'expect': ['b']},
+
+            {'inputs': {'choices': ['a', 'b', 'c'],
+                        'default': 'b'},
+             'expect': ['b']},
+
+            {'inputs': {'choices': ['a', 'b', 'c']},
+             'expect': []}
+        ]
+        for case in cases:
+            with self.subTest(case):
+                parser = self.makeParser(**case['inputs'])
+                with instrumentGooey(parser) as (app, gooeyApp):
+                    widget = gooeyApp.configs[0].reifiedWidgets[0]
+                    self.assertEqual(widget.getValue()['rawValue'], case['expect'])
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/gooey/tests/test_numeric_inputs.py
+++ b/gooey/tests/test_numeric_inputs.py
@@ -27,11 +27,33 @@ class TestNumbericInputs(unittest.TestCase):
             # the default and all works as expected.
             # this is a TODO for validation
             [{'default': 81234, 'widget': 'IntegerField', 'gooey_options': {'max': 99999}}, 81234],
+            # Initial Value cases
+            [{'widget': 'IntegerField', 'gooey_options': {'initial_value': 0}}, 0],
+            [{'widget': 'IntegerField', 'gooey_options': {'initial_value': 10}}, 10],
+            [{'widget': 'IntegerField', 'gooey_options': {'initial_value': 76}}, 76],
+            # note that WX caps the value
+            # unless explicitly widened via gooey_options
+            [{'widget': 'IntegerField', 'gooey_options': {'initial_value': 81234}}, 100],
+            # here we set the max to something higher than
+            # the default and all works as expected.
+            # this is a TODO for validation
+            [{'widget': 'IntegerField', 'gooey_options': {'initial_value': 81234, 'max': 99999}}, 81234],
 
             [{'widget': 'DecimalField'}, 0],
             [{'default': 0, 'widget': 'DecimalField'}, 0],
             [{'default': 81234, 'widget': 'DecimalField'}, 100],
             [{'default': 81234, 'widget': 'DecimalField', 'gooey_options': {'max': 99999}}, 81234],
+            # Initial Value cases
+            [{'widget': 'DecimalField', 'gooey_options': {'initial_value': 0}}, 0],
+            [{'widget': 'DecimalField', 'gooey_options': {'initial_value': 10}}, 10],
+            [{'widget': 'DecimalField', 'gooey_options': {'initial_value': 76}}, 76],
+            # note that WX caps the value
+            # unless explicitly widened via gooey_options
+            [{'widget': 'DecimalField', 'gooey_options': {'initial_value': 81234}}, 100],
+            # here we set the max to something higher than
+            # the default and all works as expected.
+            # this is a TODO for validation
+            [{'widget': 'DecimalField', 'gooey_options': {'initial_value': 81234, 'max': 99999}}, 81234],
         ]
         for inputs, expected in cases:
             with self.subTest(inputs):

--- a/gooey/tests/test_slider.py
+++ b/gooey/tests/test_slider.py
@@ -26,6 +26,19 @@ class TestGooeySlider(unittest.TestCase):
             # the default and all works as expected.
             # this is a TODO for validation
             [{'default': 81234, 'gooey_options': {'max': 99999}}, 81234],
+
+            # Initial Value cases
+            [{}, 0],
+            [{'gooey_options': {'initial_value': 0}}, 0],
+            [{'gooey_options': {'initial_value': 10}}, 10],
+            [{'gooey_options': {'initial_value': 76}}, 76],
+            # note that WX caps the value
+            # unless explicitly widened via gooey_options
+            [{'gooey_options': {'initial_value': 81234}}, 100],
+            # here we set the max to something higher than
+            # the default and all works as expected.
+            # this is a TODO for validation
+            [{'gooey_options': {'initial_value': 81234, 'max': 99999}}, 81234],
         ]
         for inputs, expected in cases:
             with self.subTest(inputs):

--- a/gooey/tests/test_textfield.py
+++ b/gooey/tests/test_textfield.py
@@ -1,8 +1,11 @@
 import unittest
+from collections import namedtuple
 
 from tests.harness import instrumentGooey
 from gooey import GooeyParser
 from gooey.tests import *
+
+Case = namedtuple('Case', 'inputs initialExpected expectedAfterClearing')
 
 class TestTextField(unittest.TestCase):
 
@@ -27,6 +30,32 @@ class TestTextField(unittest.TestCase):
                 self.assertEqual(widget.widget.GetHint(), expected)
 
 
+
+
+    def testDefaultAndInitialValue(self):
+        cases = [
+            # initial_value takes precedence when both are present
+            Case(
+                {'default': 'default_val', 'gooey_options': {'initial_value': 'some val'}},
+                'some val',
+                None),
+            # when no default is present
+            # Case({'gooey_options': {'initial_value': 'some val'}},
+            #  'some val',
+            #  ''),
+            # [{'default': 'default', 'gooey_options': {}},
+            #  'default'],
+            # [{'default': 'default'},
+            #  'default'],
+        ]
+        for case in cases:
+            parser = self.makeParser(**case.inputs)
+            with instrumentGooey(parser) as (app, gooeyApp):
+                widget = gooeyApp.configs[0].reifiedWidgets[0]
+                self.assertEqual(widget.getValue()['rawValue'], case.initialExpected)
+                widget.setValue('')
+                print(widget.getValue())
+                self.assertEqual(widget.getValue()['cmd'], case.expectedAfterClearing)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The Dropdown widget's wx.ComboBox creation used the wx.CB_DROPDOWN style flag,
which allows selection but also makes the selection editable. wx.CB_READONLY
allows selection but without editing, so the selection will always be in the
enumerated choice. See: https://docs.wxpython.org/wx.ComboBox.html#wx-combobox

Fixes: #925
