### PR TITLE
widgets: change dropdown style to readonly

### DIFF
--- a/gooey/gui/components/widgets/dropdown.py
+++ b/gooey/gui/components/widgets/dropdown.py
@@ -21,7 +21,7 @@ class Dropdown(TextContainer):
             # str conversion allows using stringyfiable values in addition to pure strings
             value=str(default),
             choices=[str(default)] + [str(choice) for choice in self._meta['choices']],
-            style=wx.CB_DROPDOWN)
+            style=wx.CB_READONLY)
 
     def setOptions(self, options):
         with self.retainSelection():


### PR DESCRIPTION
The Dropdown widget's wx.ComboBox creation used the wx.CB_DROPDOWN style flag,
which allows selection but also makes the selection editable. wx.CB_READONLY
allows selection but without editing, so the selection will always be in the
enumerated choice. See: https://docs.wxpython.org/wx.ComboBox.html#wx-combobox

Fixes: #925
