### PR TITLE
Update dependencies and versions for latest Python compatibilities

### DIFF
--- a/gooey/__init__.py
+++ b/gooey/__init__.py
@@ -5,4 +5,4 @@ from gooey.gui.util.freeze import localResourcePath as local_resource_path
 from gooey.python_bindings import constants
 from gooey.gui.components.filtering.prefix_filter import PrefixTokenizers
 from gooey.gui.components.options import options
-__version__ = '1.0.8.1'
+__version__ = '1.0.8.2'

--- a/gooey/gui/imageutil.py
+++ b/gooey/gui/imageutil.py
@@ -2,7 +2,8 @@
 Utilities for loading, resizing and converting between PIL and WX image formats
 '''
 
-import six
+import sys
+
 from PIL import Image
 import wx
 
@@ -15,7 +16,7 @@ def loadImage(img_path):
 
 
 def resizeImage(im, targetHeight):
-    im.thumbnail((six.MAXSIZE, targetHeight))
+    im.thumbnail((sys.maxsize, targetHeight))
     return im
 
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 with open('README.md') as readme:
     long_description = readme.read()
 
-version = '1.0.8.1'
+version = '1.0.8.2'
 
 deps = [
     'Pillow>=4.3.0',

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 """Script for setuptools."""
-import sys
 from setuptools import setup, find_packages
 
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setup(
     install_requires=deps,
     include_package_data=True,
     python_requires='>=3.8',
-    dependency_links = ["http://www.wxpython.org/download.php"],
     classifiers = [
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -11,13 +11,11 @@ version = '1.0.8.2'
 deps = [
     'Pillow>=4.3.0',
     'psutil>=5.4.2',
-    'colored>=1.3.93',
-    'pygtrie>=2.3.3'
+    'colored>=1.3.93,<2',
+    'pygtrie>=2.3.3',
+    'six>=1.12.0',
+    'wxpython>=4.1.0',
 ]
-
-if sys.version[0] == '3':
-    deps.append('wxpython>=4.1.0')
-
 
 setup(
     name='Gooey',

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     packages=find_packages(),
     install_requires=deps,
     include_package_data=True,
+    python_requires='>=3.8',
     dependency_links = ["http://www.wxpython.org/download.php"],
     classifiers = [
         'Development Status :: 4 - Beta',
@@ -35,8 +36,13 @@ setup(
         'Topic :: Desktop Environment',
         'Topic :: Software Development :: Build Tools',
         'Topic :: Software Development :: Widget Sets',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
         'License :: OSI Approved :: MIT License'
     ],
     long_description='''

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ deps = [
     'psutil>=5.4.2',
     'colored>=1.3.93,<2',
     'pygtrie>=2.3.3',
-    'six>=1.12.0',
     'wxpython>=4.1.0',
 ]
 


### PR DESCRIPTION
In preparation for the patch release to include Python versions 3.8-3.14. 

I locally installed this into a python 3.14 env and ran `Gooey` using `diffpy.labpdfproc` and it worked.